### PR TITLE
Allow multi line commits

### DIFF
--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -23,7 +23,7 @@ module Lolcommits
   def parse_git(dir='.')
     g = Git.open('.')
     commit = g.log.first
-    commit_msg = commit.message
+    commit_msg = commit.message.split("\n").first
     commit_sha = commit.sha[0..10]
     basename = File.basename(g.dir.to_s)
     basename.sub!(/^\./, 'dot') #no invisible directories in output, thanks!


### PR DESCRIPTION
This only takes the first line of the commit message and adds it to the
image. This way not your whole image is screwed up with longer (more
descriptive) commit messages.
