### PR TITLE
Changed delay option short to -w because disable uses -d

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -160,7 +160,7 @@ Choice.options do
     long "--delay=SECONDS"
     desc "delay taking of the snapshot by n seconds"
     cast Integer
-    short '-d'
+    short '-w'
   end
 end
 


### PR DESCRIPTION
Noticed this issue whilst testing the delay on Windows. `imagesnap` uses the `-w` flag (I suppose it means wait).
