### PR TITLE
fixed issue with annotating the photo

### DIFF
--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -142,7 +142,7 @@ module Lolcommits
     draw.annotate(canvas, 0, 0, 0, 0, word_wrap(commit_msg)) do
       self.gravity = SouthWestGravity
       self.pointsize = 48
-      self.interline_spacing = -(48 / 5)
+      self.interline_spacing = -(48 / 5) if self.respond_to?(:interline_spacing)
       self.stroke_width = 2
     end
 


### PR DESCRIPTION
On Ubuntu 10.10 when annotating photo it somehow throws an exception:

``` sh
➜  lolz git:(master) ✗ git commit -m"second commit" -a
*** Preserving this moment in history.
/home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/gems/lolcommits-0.1.2/lib/lolcommits.rb:145:in `block in capture': undefined method `interline_spacing=' for (no primitives defined):Magick::Draw (NoMethodError)
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/gems/lolcommits-0.1.2/lib/lolcommits.rb:142:in `annotate'
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/gems/lolcommits-0.1.2/lib/lolcommits.rb:142:in `capture'
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/gems/lolcommits-0.1.2/bin/lolcommits:94:in `do_capture'
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/gems/lolcommits-0.1.2/bin/lolcommits:173:in `<top (required)>'
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/bin/lolcommits:19:in `load'
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/bin/lolcommits:19:in `<main>'
[master 907f03b] second commit
 1 files changed, 1 insertions(+), 0 deletions(-)
```

so I just added one line to prevent this error. Seems like I have outdated ImageMagick or something:

``` sh
➜  lolz git:(master) ✗ ruby -v
ruby 1.9.2p290 (2011-07-09 revision 32553) [x86_64-linux]
➜  lolz git:(master) ✗ convert -v
Version: ImageMagick 6.6.2-6 2010-12-02 Q16 http://www.imagemagick.org
➜  lolz git:(master) ✗ gem list | grep rmagick
rmagick (2.5.2)
```
