### PR TITLE
Fixed installation instructions for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Likewise, you can disable it via `lolcommits --disable`.  For a full list of opt
 ## Installation (Linux)
 Install dependencies using your package manager of choice, for example in Ubuntu:
 
-    sudo apt-get install mplayer imagemagick libmagick9-dev
+    sudo apt-get install mplayer imagemagick libmagickwand-dev
 
 On Fedora, enable the rpmfusion repository (for mplayer) and run:
 


### PR DESCRIPTION
Only ligmagickwand-dev is required (which is at least on Ubuntu 12.04) in conflict with ligmagick-dev
