### PR TITLE
Creating .git/hooks if necessary

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -48,10 +48,17 @@ HOOK_PATH = File.join ".git", "hooks", "post-commit"
 # IF --ENABLE, DO ENABLE
 #
 def do_enable
-  if not File.directory?(File.join ".git", "hooks")
-    puts "You don't appear to be in the base directory of a git project."
-    exit 1
-  end
+  if not File.directory?(File.join ".git", "hooks")
+      if File.directory?(".git") 
+          Dir.mkdir(".git/hooks")
+      end
+  end
+  
+  if not File.directory?(File.join ".git", "hooks")
+    puts "You don't appear to be in the base directory of a git project."
+    exit 1
+  end
+ 
   if File.exists? HOOK_PATH
     puts "A post-commit hook already exists for this project."
     #TODO: disambiguate between OUR post-commit hook and something else


### PR DESCRIPTION
When I first installed this, I noticed that none of my repos had .git/hooks from the get-go. I had to manually create that directory before lolcommits would work. This pull request will check if .git exists and .git/hooks does not, and create .git/hooks if that is the case.
