### PR TITLE
adding twitter support

### DIFF
--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -22,6 +22,7 @@ require 'lolcommits/plugins/loltext'
 require 'lolcommits/plugins/dot_com'
 require 'lolcommits/plugins/tranzlate'
 require 'lolcommits/plugins/statsd'
+require 'lolcommits/plugins/lol_twitter'
 
 # require runner after all the plugins have been required
 require 'lolcommits/runner'

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -71,7 +71,7 @@ module Lolcommits
       puts "Available plugins: #{names.join(', ')}"
     end
 
-    def do_configure!(plugin)
+    def do_configure!(plugin, forced_options=nil)
       if plugin.nil? || plugin.strip == ''
         puts_plugins
         print "Name of plugin to configure: "
@@ -90,14 +90,19 @@ module Lolcommits
         return
       end
 
-      options = plugin_object.options.inject(Hash.new) do |acc, option|
-        print "#{option}: "
-        val = STDIN.gets.strip
-        val = true  if val == 'true'
-        val = false if val == 'false'
+      if forced_options.nil?
+        options = plugin_object.options.inject(Hash.new) do |acc, option|
+          print "#{option}: "
+          val = STDIN.gets.strip
+          val = true  if val == 'true'
+          val = false if val == 'false'
 
-        acc.merge(option => val)
+          acc.merge(option => val)
+        end
+      else
+        options = forced_options
       end
+
       config = self.user_configuration || Hash.new
       config[plugin] = options
       File.open(self.user_configuration_file, 'w') do |f| 

--- a/lib/lolcommits/plugins/lol_twitter.rb
+++ b/lib/lolcommits/plugins/lol_twitter.rb
@@ -1,0 +1,99 @@
+require 'yaml'
+require 'twitter'
+require 'oauth'
+
+TWITTER_CONSUMER_KEY = 'qc096dJJCxIiqDNUqEsqQ'
+TWITTER_CONSUMER_SECRET = 'rvjNdtwSr1H0TvBvjpk6c4bvrNydHmmbvv7gXZQI'
+
+module Lolcommits
+
+  class LolTwitter < Plugin
+
+    def initialize(runner)
+      super
+      self.name    = 'twitter'
+      self.default = false
+    end
+
+    def initial_twitter_auth
+      puts "\n--------------------------------------------"
+      puts "Need to grab twitter tokens (first time only)"
+      puts "---------------------------------------------"
+
+      consumer = OAuth::Consumer.new(TWITTER_CONSUMER_KEY, 
+                                     TWITTER_CONSUMER_SECRET,
+                                     :site => 'http://api.twitter.com',
+                                     :request_endpoint => 'http://api.twitter.com',
+                                     :sign_in => true)
+
+      request_token = consumer.get_request_token
+      rtoken  = request_token.token
+      rsecret = request_token.secret
+
+      puts "\n1.) Open the following url in your browser, get the PIN:\n\n"
+      puts request_token.authorize_url
+      puts "\n2.) Enter PIN, then press enter:"
+
+      begin
+        STDOUT.flush
+        twitter_pin = STDIN.gets.chomp
+      rescue
+      end
+
+      if (twitter_pin.nil?) || (twitter_pin.length == 0)
+        puts "\n\tERROR: Could not read PIN, auth fail"
+        return
+      end
+
+      begin
+        OAuth::RequestToken.new(consumer, rtoken, rsecret)
+        access_token = request_token.get_access_token(:oauth_verifier => twitter_pin)
+      rescue Twitter::Unauthorized
+        puts "> FAIL!"
+        return
+      end
+
+      # saves the config back to yaml file.
+      self.runner.config.do_configure!('twitter', { 'enabled'      => true,
+                                                    'access_token' => access_token.token,
+                                                    'secret'       => access_token.secret })
+    end
+
+    def run
+      commit_msg = self.runner.message
+      available_commit_msg_size = 128 
+      tweet_msg = commit_msg.length > available_commit_msg_size ? "#{commit_msg[0..(available_commit_msg_size-3)]}..." : commit_msg
+      tweet_text = "#{tweet_msg} #lolcommits"
+      puts "Tweeting: #{tweet_text}"
+
+      if configuration['access_token'].nil? || configuration['secret'].nil?
+        initial_twitter_auth()
+      end
+
+      if configuration['access_token'].nil? || configuration['secret'].nil?
+        puts "Missing Twitter Credentials - Skipping The Tweet"
+        return
+      end
+
+      Twitter.configure do |config|
+        config.consumer_key = TWITTER_CONSUMER_KEY
+        config.consumer_secret = TWITTER_CONSUMER_SECRET
+      end
+
+      client = Twitter::Client.new(
+        :oauth_token => configuration['access_token'],
+        :oauth_token_secret => configuration['secret']
+      )
+      retries = 2
+      begin
+        if client.update_with_media(tweet_text, File.open(self.runner.main_image, 'r'))
+          puts "\t--> Tweet Sent!"
+        end
+      rescue Twitter::Error::InternalServerError
+        retries -= 1
+        retry if retries > 0
+        puts "\t ! --> Tweet 500 Error - Tweet Not Posted"
+      end
+    end
+  end
+end

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -12,6 +12,7 @@ module Lolcommits
 
     # Executed Last
     set_callback :run, :after,  :cleanup!
+    set_callback :run, :after,  :execute_lolcommits_lol_twitter
     set_callback :run, :after,  :execute_lolcommits_stats_d
     set_callback :run, :after,  :execute_lolcommits_dot_com
     set_callback :run, :after,  :execute_lolcommits_loltext

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('git', '~> 1.2.5')
   s.add_runtime_dependency('choice', '~> 0.1.6')
   s.add_runtime_dependency('launchy', '~> 2.1.1')
+  s.add_runtime_dependency("twitter")
+  s.add_runtime_dependency("oauth")
 
   s.add_development_dependency('rdoc')
   s.add_development_dependency('aruba')


### PR DESCRIPTION
Hey there, I took a crack at adding twitter support to lolcommits. 

So basically this patch takes care of asking them if twitter is desired during lolcommits --enable, and if so, it will then at capture time, take care of running the user through a pin-based oauth flow, and storing oauth tokens in ~/.lolcommits/.tw_auth

One snafu is that I had to create a twitter application so that this would work.  I could change the code so that it requires one to enter their own twitter oauth application, or configurable or something, but as of now, if these ones are used (lib/lolcommits.rb lines 16/17) it will say "sent from lolcommits".

Anyhow, suggestions completely welcome.  This is just a first stab, but thought it would be interesting to capture some of the lolcommit action on twitter.
