### PR TITLE
fix no method error for tmp dir configuration

### DIFF
--- a/lib/lolcommits/capture_linux.rb
+++ b/lib/lolcommits/capture_linux.rb
@@ -1,8 +1,7 @@
 module Lolcommits
   class CaptureLinux < Capturer
     def capture
-      tmpdir = File.expand_path "#{Configuration.loldir}/tmpdir#{rand(1000)}/"
-      FileUtils.mkdir_p( tmpdir )
+      tmpdir = Dir.mktmpdir
       # There's no way to give a capture delay in mplayer, but a number of frame
       # I've found that 6 is a good value for me.
       frames = if capture_delay != 0 then capture_delay else 6 end


### PR DESCRIPTION
The configuration call in the `CaptureLinux` class `Configuration.loldir` is invalid (no method).

I replaced that statement by the core method to create a tmp dir, there is no need for custom tmp dir handling.
