### PR TITLE
active_support is not the canonical version

### DIFF
--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('launchy', '~> 2.1.1')
   s.add_runtime_dependency('methadone', '~> 1.2.4')
   s.add_runtime_dependency('open4', '~> 1.3.0')
-  s.add_runtime_dependency('active_support', '~> 3.0.0')
+  s.add_runtime_dependency('activesupport', '~> 3.0.0')
 
   # development dependencies
   s.add_development_dependency('rdoc')


### PR DESCRIPTION
the correct gem name is just 'activesupport'
