### PR TITLE
External devices with spaces in them fail

### DIFF
--- a/lib/lolcommits/capture_mac.rb
+++ b/lib/lolcommits/capture_mac.rb
@@ -1,7 +1,7 @@
 module Lolcommits
   class CaptureMac < Capturer
     def capture_device_string
-      @capture_device.nil? ? nil : "-d #{@capture_device.gsub(' ','\ ')}"
+      @capture_device.nil? ? nil : "-d \"#{@capture_device}\""
     end
 
     def capture


### PR DESCRIPTION
I'm not sure if this is a universal problem but for me, when trying to use a device with a space in the name, imagesnap only searches for the first word of the device. 

``` BASH
$ lolcommits -c --test --device='Display iSight'                                                            
*** Capturing in test mode.
*** Preserving this moment in history.
Device "Display" not found.
/usr/local/opt/rbenv/versions/1.9.3-p385/lib/ruby/gems/1.9.1/gems/mini_magick-3.5.0/lib/mini_magick.rb:136:in `initialize': No such file or directory - /Users/msplain/.lolcommits/test/tmp_snapshot.jpg (Errno::ENOENT)
```
