### PR TITLE
disable statsd plugin by default

### DIFF
--- a/lib/lolcommits/plugins/statsd.rb
+++ b/lib/lolcommits/plugins/statsd.rb
@@ -10,7 +10,7 @@ module Lolcommits
       super
 
       self.name    = 'statsd'
-      self.default = true
+      self.default = false
     end
 
     def run


### PR DESCRIPTION
To be honest I was really surprised when I've seen that lolcommits tries to send a UDP message to some IP (http://ec2-23-20-178-143.compute-1.amazonaws.com/) by default. 

When I do understand the code correct you do that to collect some stats about the usage of the gem? 
This pull request disables the Statsd plugin by default. I'm aware that probably nobody enables this and thus you do not get the stats but I think the user of this gem should be informed about this.
thanks
