### PR TITLE
Adding new LOLCOMMITS_FORK (or --fork) option to fork the runner capturing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ By default, the lolimages are stored by a Github style short SHA in a `~/.lolcom
 
 Please add your own lolcommit! Add to the [People Using Lolcommits](https://github.com/mroth/lolcommits/wiki/People-Using-Lolcommits) page on the Wiki.
 
-## Installation 
+## Installation
 ### Mac OS X
 You'll need ImageMagick installed.  [Homebrew](http://mxcl.github.com/homebrew/) makes this easy.  Simply do:
 
@@ -57,6 +57,8 @@ environment variables.
  * Set delay persistently (for slow to warmup webcams) - set
    `LOLCOMMITS_DELAY` var to time in seconds.
  * Set font file location - set `LOLCOMMITS_FONT` environment variable.
+ * Fork lolcommits runner - set `LOLCOMMITS_FORK` environment variable
+   (causes capturing command to fork to a new process, speedily returning you to your terminal).
 
 For the full list, see the [configuration variables](https://github.com/mroth/lolcommits/wiki/Configuration-Variables).
 

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -134,25 +134,35 @@ def do_capture
   capture_device = Choice.choices[:device] || ENV['LOLCOMMITS_DEVICE'] || nil
   capture_font = Choice.choices[:font] || ENV['LOLCOMMITS_FONT'] || nil
 
-  if Choice.choices[:test]
-    info "*** Capturing in test mode."
-    runner = Lolcommits::Runner.new(:capture_delay => capture_delay,
-      :capture_device => capture_device,
-      :message        => Choice.choices[:msg],
-      :sha            => Choice.choices[:sha],
-      :config         => configuration,
-      :font           => capture_font
-   )
-    runner.run
-
-    Launchy.open(runner.main_image)
-  else
-    runner = Lolcommits::Runner.new(:capture_delay => capture_delay,
-      :capture_device => capture_device,
-      :config         => configuration,
-      :font           => capture_font
+  fork_me? do
+    if Choice.choices[:test]
+      info "*** Capturing in test mode."
+      runner = Lolcommits::Runner.new(:capture_delay => capture_delay,
+        :capture_device => capture_device,
+        :message        => Choice.choices[:msg],
+        :sha            => Choice.choices[:sha],
+        :config         => configuration,
+        :font           => capture_font
     )
-    runner.run
+      runner.run
+
+      Launchy.open(runner.main_image)
+    else
+      runner = Lolcommits::Runner.new(:capture_delay => capture_delay,
+        :capture_device => capture_device,
+        :config         => configuration,
+        :font           => capture_font
+      )
+      runner.run
+    end
+  end
+end
+
+def fork_me?(&block)
+  if Choice.choices[:fork] || ENV['LOLCOMMITS_FORK']
+    fork { yield block }
+  else
+    yield block
   end
 end
 
@@ -305,6 +315,10 @@ Choice.options do
     desc "generate animated gif"
   end
 
+  option :fork do
+    long "--fork"
+    desc "fork the lolcommits runner to the background"
+  end
 end
 
 # Set debug level if needed


### PR DESCRIPTION
Use the `LOLCOMMITS_FORK` env variable or `--fork` argument in the lolcommits command to fork the runner capturing process to a new thread.  

This helps when the capture is slow and you want to return to a usable terminal prompt right away.  Using fork, some plugins may prompt in your terminal after the initial capture. I also updated the README.md to explain this.

This PR is particularly useful for [capturing animated gifs](https://github.com/mroth/lolcommits/pull/108)!
