### PR TITLE
better feature for testing `--fork` option (resubmitted)

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -160,10 +160,26 @@ end
 
 def fork_me?(&block)
   if Choice.choices[:fork] || ENV['LOLCOMMITS_FORK']
-    fork { yield block }
+    $stdout.sync = true
+    write_pid fork {
+      yield block
+      delete_pid
+    }
   else
     yield block
   end
+end
+
+def write_pid(pid)
+  File.open(pid_file, 'w') { |f| f.write(pid) }
+end
+
+def delete_pid
+  File.delete(pid_file) if File.exist?(pid_file)
+end
+
+def pid_file
+  File.join(configuration.loldir, 'lolcommits.pid')
 end
 
 def do_configure

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -31,7 +31,8 @@ Feature: Basic UI functionality
     Given I am in a git repository named "testforkcapture"
     And I do a git commit
     When I successfully run `lolcommits --capture --fork`
-    And I successfully run `sleep 3`
+    Then there should be exactly 1 pid in "../.lolcommits/testforkcapture"
+    When I wait for the child process to exit in "testforkcapture"
     Then the output should contain "*** Preserving this moment in history."
       And a directory named "../.lolcommits/testforkcapture" should exist
       And a file named "../.lolcommits/testforkcapture/tmp_snapshot.jpg" should not exist
@@ -90,7 +91,7 @@ Feature: Basic UI functionality
     When I successfully run `lolcommits --show-config`
     Then the output should contain "loltext:"
     And the output should contain "enabled: true"
-  
+
   Scenario: Configuring Plugin In Test Mode
     Given a git repository named "testmode-config-test"
     When I cd to "testmode-config-test"

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -70,7 +70,7 @@ When /^I enter "(.*?)" for "(.*?)"$/ do |input, field|
   @stdin.puts input
 end
 
-Then /^there should be (?:exactly|only) (.*?) (jpg|gif)(?:s?) in "(.*?)"$/ do |n, type, folder|
+Then /^there should be (?:exactly|only) (.*?) (jpg|gif|pid)(?:s?) in "(.*?)"$/ do |n, type, folder|
   assert_equal n.to_i, Dir["#{current_dir}/#{folder}/*.#{type}"].count
 end
 
@@ -102,3 +102,8 @@ Then /^there should be (\d+) commit entries in the git log$/ do |n|
   assert_equal n.to_i, `git shortlog | grep -E '^[ ]+\w+' | wc -l`.chomp.to_i
 end
 
+When /^I wait for the child process to exit in "(.*?)"$/ do |repo_name|
+  while File.exist?("tmp/aruba/.lolcommits/#{repo_name}/lolcommits.pid")
+    sleep 0.1
+  end
+end


### PR DESCRIPTION
Adding this as a separate PR. 

It basically improves the feature testing the `--fork` option.  With this change forking writes to an `lolcommits.pid` file (in `configuration.loldir`) with the forking process id (standard practice for this sort of thing).  Lolcommits captures as normal in the forked process and then deletes this pid file when its done.

The test the checks for the presence of this file and waits until it gets cleared before testing if the capture worked.

:books:  quick history lesson, these changes were originally issued in [this PR](https://github.com/mroth/lolcommits/pull/110) that included some other things, and was eventually reverted when we rolled back the 0.5 release (the one with animated gif generating for the mac)

I think its worth adding this back in to improve the test suite, no new gem release is required.
