### PR TITLE
Use LOLCOMMITS_DEVICE option on Linux.

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -311,7 +311,7 @@ Choice.options do
 
   option :device do
     long "--device=DEVICE"
-    desc "the device name used to take the snapshot (only mac)"
+    desc "the device name used to take the snapshot (only mac/linux)"
   end
 
   option :debug do

--- a/lib/lolcommits/capture_linux.rb
+++ b/lib/lolcommits/capture_linux.rb
@@ -1,5 +1,9 @@
 module Lolcommits
   class CaptureLinux < Capturer
+    def capture_device_string
+      @capture_device.nil? ? nil : "-tv device=\"#{@capture_device}\""
+    end
+
     def capture
       debug "LinuxCapturer: making tmp directory"
       tmpdir = Dir.mktmpdir
@@ -14,7 +18,7 @@ module Lolcommits
 
       debug "LinuxCapturer: calling out to mplayer to capture image"
       # mplayer's output is ugly and useless, let's throw it away
-      _, r, _ = Open3.popen3("mplayer -vo jpeg:outdir=#{tmpdir} -frames #{frames} tv://")
+      _, r, _ = Open3.popen3("mplayer -vo jpeg:outdir=#{tmpdir} #{capture_device_string} -frames #{frames} tv://")
       # looks like we still need to read the output for something to happen
       r.read
 


### PR DESCRIPTION
This is just a small tweak to use the `LOLCOMMITS_DEVICE` option on Linux, based on the information at https://github.com/mroth/lolcommits/wiki/FAQ.

```
$ lolcommits -c --test --device "/dev/video1"
```

Works well on my Arch Linux machine :camera: 
