### PR TITLE
Parse repo names with dashes

### DIFF
--- a/lib/lolcommits/git_info.rb
+++ b/lib/lolcommits/git_info.rb
@@ -13,7 +13,7 @@ module Lolcommits
       self.message = commit.message.split("\n").first
       self.sha     = commit.sha[0..10]
       self.repo_internal_path = g.repo.path
-      regex = /.*[:\/](\w*).git/
+      regex = /.*[:\/]([\w\-]*).git/
       match = g.remote.url.match regex if g.remote.url
       self.repo = match[1] if match
       


### PR DESCRIPTION
Hi,

We have a lot of repos with dashes in their names. This change allows dashes in the names as well as words.

This should fix mroth/lolcommits#144
