### PR TITLE
Fix comparaison error for animate?

### DIFF
--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -56,7 +56,7 @@ module Lolcommits
     end
 
     def animate?
-      capture_animate && (capture_animate > 0)
+      capture_animate && (capture_animate.to_i > 0)
     end
 
     private


### PR DESCRIPTION
I had this:
/Library/Ruby/Gems/1.8/gems/lolcommits-0.5.0/lib/lolcommits/runner.rb:59:in `>': comparison of String with 0 failed (ArgumentError)

So I made a little fix for it, animate works fine with it.
