### PR TITLE
Improved --enable option, accepts passing arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,32 @@ From within any git repository, simply do a `lolcommits --enable`. From that poi
 Don't worry about it too much, half the fun of lolcommits is forgetting it's installed!
 
 ### Other commands
-Ok, if you insist... Since you know about `--enable`, common sense suggest there is also a repository specific `--disable`, hopefully you can guess what that does. Other handy common commands include `--last`, which will open for display your most recent lolcommit image, or `--browse`, which pops open the directory containing all the lolcommit images for your current repository. You can always do `--help` for a full list of available commands.
+Ok, if you insist... Since you know about `--enable`, common sense suggests there is also a repository specific `--disable`, hopefully you can guess what that does. Other handy common commands include `--last`, which will open for display your most recent lolcommit image, or `--browse`, which pops open the directory containing all the lolcommit images for your current repository. You can always do `--help` for a full list of available commands.
 
-### Configuration variables
-lolcommits has some options for additional lulz.  You can enable via
-environment variables.
+**NOTE**: Any extra arguments you pass with the --enable command are auto-appended to the git-commit capture command.  For example;
 
- * Set webcam device on mac - set `LOLCOMMITS_DEVICE` environment variable.
- * Set delay persistently (for slow to warmup webcams) - set
-   `LOLCOMMITS_DELAY` var to time in seconds.
- * Set font file location - set `LOLCOMMITS_FONT` environment variable.
- * Animated gifs - set `LOLCOMMITS_ANIMATE=3` (currently Mac/OSX only and requires `ffmpeg`).
- * Fork lolcommits runner - set `LOLCOMMITS_FORK` environment variable
-   (causes capturing command to fork to a new process, speedily returning you to your terminal).
- * Disable the notification at commit time - set `LOLCOMMITS_STEALTH` environment variable.
+    lolcommits --enable --delay=5 --animate=4 --fork
+
+Will configure capturing of an animated gif (4 secs) after a 5 sec delay in a forked process. See the section below for more capture configuration variables.
+
+### Capture configuration variables
+lolcommits has some capture options for additional lulz. You can enable these via environment variables like so;
+
+* `LOLCOMMITS_DEVICE` set a webcam device - **mac and linux only**
+* `LOLCOMMITS_ANIMATE` (in seconds) set time for capturing an animated gif - **mac only & requires ffmpeg**
+* `LOLCOMMITS_DELAY` (in seconds) set delay persistently (for slow webcams to warmup)
+* `LOLCOMMITS_FONT` set font file location for lolcommit text
+* `LOLCOMMITS_FORK` fork lolcommit runner (capture command forks to a new process, speedily returning you to your terminal)
+* `LOLCOMMITS_STEALTH` disable notification messages at commit time
+
+Or they can be set via the following arguments in the capture command (located in your repository's `.git/hooks/post-commit` file).
+
+* `--device=DEVICE` or `-d DEVICE`
+* `--animate=SECONDS` or `-a SECONDS`
+* `--delay=SECONDS` or `-w SECONDS`
+* `--font=FONT_PATH` or `-f FONT_PATH`
+* `--fork`
+* `--stealth`
 
 Read how to [configure commit capturing](https://github.com/mroth/lolcommits/wiki/Configure-Commit-Capturing) for more details.
 

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -95,16 +95,29 @@ def do_enable
     exit 1
   end
 
-  ruby_path   = Lolcommits::Configuration.command_which('ruby')
-  hook_export = "export PATH=\"#{ruby_path}:$PATH\"\n" if ruby_path
-  doc = "#!/bin/sh\n#{hook_export}lolcommits --capture\n"
-  File.open(HOOK_PATH, 'w') {|f| f.write(doc) }
+  File.open(HOOK_PATH, 'w') {|f| f.write(hook_script) }
   FileUtils.chmod 0755, HOOK_PATH
-  info "installed lolcommmit hook as:"
+  info "installed lolcommmit hook to:"
   info "  -> #{File.expand_path(HOOK_PATH)}"
   info "(to remove later, you can use: lolcommits --disable)"
   # we dont symlink, but rather install a small stub that calls the one from path
   # that way, as gem version changes, script updates even if new file thus breaking symlink
+end
+
+def hook_script
+  shebang      = "#!/bin/sh"
+  ruby_path    = Lolcommits::Configuration.command_which('ruby')
+  hook_export  = "export PATH=\"#{ruby_path}:$PATH\"\n" if ruby_path
+  capture_cmd  = "lolcommits --capture"
+  capture_args = " #{ARGV[1..-1].join(' ')}" if ARGV.length > 1
+
+  <<-EOS
+#{shebang}
+
+### lolcommits hook (begin) ###
+#{hook_export}#{capture_cmd}#{capture_args}
+###  lolcommits hook (end)  ###
+EOS
 end
 
 #

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -21,9 +21,20 @@ Feature: Basic UI functionality
     Given a git repository named "loltest" with no "post-commit" hook
     When I cd to "loltest"
     And I successfully run `lolcommits --enable`
-    Then the output should contain "installed lolcommmit hook as:"
+    Then the output should contain "installed lolcommmit hook to:"
       And the output should contain "(to remove later, you can use: lolcommits --disable)"
       And a file named ".git/hooks/post-commit" should exist
+      And the file ".git/hooks/post-commit" should contain "lolcommits --capture"
+      And the exit status should be 0
+
+  Scenario: Enable in a git repository passing capture arguments
+    Given a git repository named "loltest" with no "post-commit" hook
+    When I cd to "loltest"
+    And I successfully run `lolcommits --enable -w 5 --fork`
+    Then the output should contain "installed lolcommmit hook to:"
+      And the output should contain "(to remove later, you can use: lolcommits --disable)"
+      And a file named ".git/hooks/post-commit" should exist
+      And the file ".git/hooks/post-commit" should contain "lolcommits --capture -w 5 --fork"
       And the exit status should be 0
 
   Scenario: Disable in a enabled git repository


### PR DESCRIPTION
Improved the `--enable` option to work better with existing post-commit hooks.  Any additional args after the --enable option are passed through to the --capture command within the hook.  

For example calling;

```
lolcommits --enable --animate=5 --fork
```

would result in the following capture hook

```
#!/bin/sh

### lolcommits hook (begin) ###
export PATH="/Users/xxx/.rbenv/versions/2.0.0-p247/bin/ruby:$PATH"
lolcommits --capture --animate=5 --fork
###  lolcommits hook (end) ###
```
- added a feature to test the lolcommits hook enabling with args
- added lolcommits comments before and after the hook commands
- tests are green
