### PR TITLE
fix json gem issue #163

### DIFF
--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -39,6 +39,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('oauth')                   #twitter
   s.add_runtime_dependency('rest-client')             #uploldz
   s.add_runtime_dependency('httmultiparty')           #dot_com
+  s.add_runtime_dependency('httparty', "~> 0.11.0")   #dot_com
   s.add_runtime_dependency('json', '~> 1.7.6')        #lolsrv
+  s.add_runtime_dependency('mime-types', '~> 1.25')
 
 end


### PR DESCRIPTION
Fixing issue #163 but locking httparty dependency to `0.11.0` so that json `~> 1.7.6` can still work.

Also since we're still supporting Ruby 1.8.7 i've changed our dependency on the mime-type gem to `~> 1.2.5`.  Recently mine-types [2.0](http://rubygems.org/gems/mime-types/versions/2.0) was released (28th Oct) which requires >= Ruby 1.9.3.
