### PR TITLE
better post commit hook enabling/disabling

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -62,6 +62,35 @@ def die_if_not_git_repo!
   end
 end
 
+def good_shebang?
+  File.read(HOOK_PATH).lines.first =~ /^\#\!\/bin\/.*sh/
+end
+
+def lolcommits_hook?
+  File.exists?(HOOK_PATH) &&
+    File.read(HOOK_PATH).to_s =~ /lolcommits.*\(begin\)(.*\n)*.*lolcommits.*\(end\)/
+end
+
+def remove_existing_hook
+  hook = File.read(HOOK_PATH)
+  out  = File.open(HOOK_PATH, 'w')
+  skip = false
+
+  hook.lines.each do |line|
+    if !skip && (line =~ /lolcommits.*\(begin\)/)
+      skip = true
+    end
+
+    out << line unless skip
+
+    if skip && (line =~ /lolcommits.*\(end\)/)
+      skip = false
+    end
+  end
+
+  out.close
+end
+
 #
 # NO ARGUMENTS SPECIFIED, HELP THE USER OUT
 #
@@ -89,14 +118,23 @@ def do_enable
     Dir.mkdir(HOOK_DIR)
   end
 
-  if File.exists? HOOK_PATH
-    fatal "A post-commit hook already exists for this project."
-    #TODO: disambiguate between OUR post-commit hook and something else
-    exit 1
+  # clear away any existing lolcommits hook
+  if hook_exists = File.exists?(HOOK_PATH)
+    remove_existing_hook
+
+    # check for a good shebang line in the existing hook
+    unless good_shebang?
+      warn "the existing hook (at #{HOOK_PATH}) doesn't start with with a good shebang; like #!/bin/sh"
+      exit 1
+    end
   end
 
-  File.open(HOOK_PATH, 'w') {|f| f.write(hook_script) }
+  File.open(HOOK_PATH, hook_exists ? 'a' : 'w') do |f|
+    f.write(hook_script(!hook_exists))
+  end
+
   FileUtils.chmod 0755, HOOK_PATH
+
   info "installed lolcommmit hook to:"
   info "  -> #{File.expand_path(HOOK_PATH)}"
   info "(to remove later, you can use: lolcommits --disable)"
@@ -104,17 +142,15 @@ def do_enable
   # that way, as gem version changes, script updates even if new file thus breaking symlink
 end
 
-def hook_script
-  shebang      = "#!/bin/sh"
+def hook_script(add_shebang = true)
+  shebang      = add_shebang ? "#!/bin/sh\n\n" : ''
   ruby_path    = Lolcommits::Configuration.command_which('ruby')
   hook_export  = "export PATH=\"#{ruby_path}:$PATH\"\n" if ruby_path
-  capture_cmd  = "lolcommits --capture"
+  capture_cmd  = 'lolcommits --capture'
   capture_args = " #{ARGV[1..-1].join(' ')}" if ARGV.length > 1
 
   <<-EOS
-#{shebang}
-
-### lolcommits hook (begin) ###
+#{shebang}### lolcommits hook (begin) ###
 #{hook_export}#{capture_cmd}#{capture_args}
 ###  lolcommits hook (end)  ###
 EOS
@@ -124,12 +160,16 @@ end
 # IF --DISABLE, DO DISABLE
 #
 def do_disable
-  if File.exists? HOOK_PATH
-    #TODO: check if hook file has been modified before removing
-    FileUtils.rm HOOK_PATH
-    info "removed #{HOOK_PATH}"
+  if lolcommits_hook?
+    remove_existing_hook
+    info "uninstalled lolcommits hook (from #{HOOK_PATH})"
+  elsif File.exists?(HOOK_PATH)
+    info "couldn't find an lolcommits hook (at #{HOOK_PATH})"
+    if File.read(HOOK_PATH) =~ /lolcommit/
+      info "warning: an older-style lolcommit hook may still exist, edit #{HOOK_PATH} to remove it manually"
+    end
   else
-    info "lolcommits is not enabled for this directory, so there is nothing to uninstall."
+    info "no post commit hook found (at #{HOOK_PATH}), so there is nothing to uninstall"
   end
 end
 

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -27,6 +27,28 @@ Feature: Basic UI functionality
       And the file ".git/hooks/post-commit" should contain "lolcommits --capture"
       And the exit status should be 0
 
+  Scenario: Enable in a git repository that already has a post-commit hook
+    Given a git repository named "loltest" with a "post-commit" hook
+      And the "loltest" repository "post-commit" hook has content "#!/bin/sh\n\n/my/own/script"
+    When I cd to "loltest"
+    And I successfully run `lolcommits --enable`
+    Then the output should contain "installed lolcommmit hook to:"
+      And the output should contain "(to remove later, you can use: lolcommits --disable)"
+      And a file named ".git/hooks/post-commit" should exist
+      And the file ".git/hooks/post-commit" should contain "#!/bin/sh"
+      And the file ".git/hooks/post-commit" should contain "/my/own/script"
+      And the file ".git/hooks/post-commit" should contain "lolcommits --capture"
+      And the exit status should be 0
+
+  Scenario: Enable in a git repository that already has post-commit hook with a bad shebang
+    Given a git repository named "loltest" with a "post-commit" hook
+      And the "loltest" repository "post-commit" hook has content "#!/bin/ruby"
+    When I cd to "loltest"
+    And I run `lolcommits --enable`
+    Then the output should contain "doesn't start with with a good shebang"
+      And the file ".git/hooks/post-commit" should not contain "lolcommits --capture"
+      And the exit status should be 1
+
   Scenario: Enable in a git repository passing capture arguments
     Given a git repository named "loltest" with no "post-commit" hook
     When I cd to "loltest"
@@ -40,8 +62,9 @@ Feature: Basic UI functionality
   Scenario: Disable in a enabled git repository
     Given I am in a git repository named "lolenabled" with lolcommits enabled
     When I successfully run `lolcommits --disable`
-    Then the output should contain "removed"
-      And a file named ".git/hooks/post-commit" should not exist
+    Then the output should contain "uninstalled"
+      And a file named ".git/hooks/post-commit" should exist
+      And the file ".git/hooks/post-commit" should not contain "lolcommits --capture"
       And the exit status should be 0
 
   Scenario: Trying to enable while not in a git repo fails

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -27,6 +27,12 @@ Given /^the git repository named "(.*?)" has a "(.*?)" hook$/ do |repo_name, hoo
   touch(hook_file) if not File.exists? hook_file
 end
 
+Given /^the "(.*?)" repository "(.*?)" hook has content "(.*?)"$/ do |repo_name, hook_name, hook_content|
+  step %{the git repository named "#{repo_name}" has a "#{hook_name}" hook}
+  hook_file = File.join current_dir, repo_name, ".git", "hooks", hook_name
+  File.open(hook_file, 'w') { |f| f.write(hook_content) }
+end
+
 Given /^a git repository named "(.*?)" with (a|no) "(.*?)" hook$/ do |repo_name, yesno_modifier, hook_name|
   step %{a git repository named "#{repo_name}"}
   step %{the git repository named "#{repo_name}" has #{yesno_modifier} "#{hook_name}" hook}


### PR DESCRIPTION
Some improvements to hook enabling and disabling.  Includes new scenarios to test these features.
(no specific issue addressed here, but there was a TODO in the code comments)
- if --enabling when an existing hook is present
  - now removes any existing lolcommit hook lines first
  - and checks for a good shebang line (aborts with warn message if not found)
- --enable works as before if no post-commit is present
- if --disabling
  - when existing hook is present, removes the lolcommit lines only
  - warns if any lolcommits hook might still be present (in old style), message says to edit manually to uninstall
  - shows info message if no post-commit file found at all
