### PR TITLE
fix for gem dependency issue #175

### DIFF
--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('travis')
 
   # plugin dependencies
-  s.add_runtime_dependency('twitter')                 #twitter
+  s.add_runtime_dependency('twitter', '~> 4.8.1')     #twitter
   s.add_runtime_dependency('oauth')                   #twitter
   s.add_runtime_dependency('rest-client')             #uploldz
   s.add_runtime_dependency('httmultiparty')           #dot_com


### PR DESCRIPTION
Twitter gem `5.0.0` was recently released (18th Nov) and causes issues with our dependency on;  json, '~> 1.7.6'

:lock: - This PR locks the Twitter gem we use to `~> 4.8.1`.

:newspaper:  - Work will be underway soon to update all gem dependencies in lolcommits, and use (more up-to-date) specific versions set in lolcommits.gemspec.
