### PR TITLE
Plugins refactoring & twitter fixes for #73 and #136

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -440,7 +440,7 @@ if not (Choice.choices[:enable] || Choice.choices[:disable])
   elsif Choice.choices[:configure]
     do_configure()
   elsif Choice.choices[:show_config]
-    puts configuration.user_configuration.to_yaml
+    puts configuration
   elsif Choice.choices[:plugins]
     configuration.puts_plugins()
   elsif Choice.choices[:last]

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -134,7 +134,7 @@ Feature: Basic UI functionality
     Then the output should contain a list of plugins
     And the output should contain "Name of plugin to configure:"
     Then the output should contain "enabled:"
-    Then the output should contain "Successfully Configured"
+    Then the output should contain "Successfully configured plugin: loltext"
     And a file named "../.lolcommits/config-test/config.yml" should exist
     When I successfully run `lolcommits --show-config`
     Then the output should contain "loltext:"
@@ -146,7 +146,7 @@ Feature: Basic UI functionality
     And I run `lolcommits --config` and wait for output
     When I enter "loltext" for "Name of plugin to configure"
     And I enter "true" for "enabled"
-    Then I should be presented "Successfully Configured"
+    Then I should be presented "Successfully configured plugin: loltext"
     And a file named "../.lolcommits/config-test/config.yml" should exist
     When I successfully run `lolcommits --show-config`
     Then the output should contain "loltext:"
@@ -158,7 +158,7 @@ Feature: Basic UI functionality
     And I run `lolcommits --config --test` and wait for output
     And I enter "loltext" for "Name of plugin to configure"
     And I enter "true" for "enabled"
-    Then I should be presented "Successfully Configured"
+    Then I should be presented "Successfully configured plugin: loltext"
     And a file named "../.lolcommits/test/config.yml" should exist
     When I successfully run `lolcommits --test --show-config`
     Then the output should contain "loltext:"

--- a/features/plugins.feature
+++ b/features/plugins.feature
@@ -9,7 +9,7 @@ Feature: Plugins Work
     And I enter "b2a70ac0b64e012fa61522000a8c42dc" for "api_key"
     And I enter "b2a720b0b64e012fa61522000a8c42dc" for "api_secret"
     And I enter "c4aed530b64e012fa61522000a8c42dc" for "repo_id"
-    Then I should be presented "Successfully Configured"
+    Then I should be presented "Successfully configured plugin: dot_com"
     When I do a git commit
     Then the output should contain "*** Preserving this moment in history."
     And there should be exactly 1 jpg in "../.lolcommits/dot_com"
@@ -19,7 +19,7 @@ Feature: Plugins Work
     And I run `lolcommits --config` and wait for output
     And I enter "loltext" for "Plugin Name"
     And I enter "false" for "enabled"
-    Then I should be presented "Successfully Configured"
+    Then I should be presented "Successfully configured plugin: loltext"
     When I do a git commit
     Then the output should contain "*** Preserving this moment in history."
     And there should be exactly 1 jpg in "../.lolcommits/loltext"
@@ -30,8 +30,8 @@ Feature: Plugins Work
     And I enter "lolsrv" for "Plugin Name"
     And I enter "true" for "enabled"
     And I enter "http://localhost" for "server"
-    Then I should be presented "Successfully Configured"
+    Then I should be presented "Successfully configured plugin: lolsrv"
     When I do a git commit
     Then the output should contain "*** Preserving this moment in history."
     And there should be exactly 1 jpg in "../.lolcommits/lolsrv"
-    
+

--- a/lib/lolcommits/plugin.rb
+++ b/lib/lolcommits/plugin.rb
@@ -1,40 +1,83 @@
 module Lolcommits
   class Plugin
     include Methadone::CLILogging
-    attr_accessor :default, :name, :runner, :options
 
-    def configuration
-      config = runner.config.user_configuration
-      return Hash.new if config.nil?
-      config[self.name] || Hash.new
-    end
+    attr_accessor :runner, :options
 
     def initialize(runner)
+      debug "Initializing"
       self.runner = runner
       self.options = ['enabled']
-
-      plugdebug "Initializing"
     end
-
-    def is_enabled?
-      enabled_config = configuration['enabled']
-      return self.default if enabled_config.nil? || enabled_config == ''
-      return enabled_config
-    end
-
 
     def execute
       if is_enabled?
-        plugdebug "I am enabled, about to run"
+        debug "I am enabled, about to run"
         run
       else
-        plugdebug "Disabled, doing nothing for execution"
+        debug "Disabled, doing nothing for execution"
       end
     end
 
-    # uniform debug logging output for plugins
-    def plugdebug(msg)
-      debug("Plugin: #{self.class.to_s}: " + msg)
+    def run
+      debug "base plugin, does nothing to anything"
+    end
+
+    def configuration
+      config = runner.config.read_configuration if runner
+      return Hash.new unless config
+      config[self.class.name] || Hash.new
+    end
+
+    # ask for plugin options
+    def configure_options!
+      puts "Configuring plugin: #{self.class.name}\n"
+      options.inject(Hash.new) do |acc, option|
+        print "#{option}: "
+        val = STDIN.gets.strip.downcase
+        if %w(true yes).include?(val)
+          val = true
+        elsif %(false no).include?(val)
+          val = false
+        end
+        acc.merge(option => val)
+      end
+    end
+
+    def is_enabled?
+      configuration['enabled'] == true
+    end
+
+    # check config is valid
+    def valid_configuration?
+      if is_configured?
+        true
+      else
+        puts "Missing #{self.class.name} config - configure with: lolcommits --config -p #{self.class.name}"
+        false
+      end
+    end
+
+    # empty plugin configuration
+    def is_configured?
+      !configuration.empty?
+    end
+
+    # uniform puts for plugins
+    # dont puts if the runner wants to be silent (stealth mode)
+    def puts(*args)
+      return if runner && runner.capture_stealth
+      super(args)
+    end
+
+    # uniform debug logging for plugins
+    def debug(msg)
+      super("Plugin: #{self.class.to_s}: " + msg)
+    end
+
+    # identifying plugin name (for config, listing)
+    def self.name
+      'plugin'
     end
   end
 end

--- a/lib/lolcommits/plugins/dot_com.rb
+++ b/lib/lolcommits/plugins/dot_com.rb
@@ -2,17 +2,17 @@ require 'httmultiparty'
 
 module Lolcommits
   class DotCom < Plugin
+
     def initialize(runner)
       super
-
-      self.name    = 'dot_com'
-      self.default = false
       self.options.concat(['api_key', 'api_secret', 'repo_id'])
     end
 
     def run
+      return unless valid_configuration?
+
       t = Time.now.to_i.to_s
-      resp = HTTMultiParty.post('http://www.lolcommits.com/git_commits.json', 
+      resp = HTTMultiParty.post('http://www.lolcommits.com/git_commits.json',
         :body => {
           :git_commit => {
             :sha              => self.runner.sha,
@@ -28,5 +28,15 @@ module Lolcommits
       )
     end
 
+    def is_configured?
+      !configuration['enabled'].nil? &&
+        configuration['api_key'] &&
+        configuration['api_secret'] &&
+        configuration['repo_id']
+    end
+
+    def self.name
+      'dot_com'
+    end
   end
 end

--- a/lib/lolcommits/plugins/lolsrv.rb
+++ b/lib/lolcommits/plugins/lolsrv.rb
@@ -4,42 +4,33 @@ require "json"
 require "logger"
 
 module Lolcommits
-
   class Lolsrv < Plugin
-
-    SERVER = 'server'
 
     def initialize(runner)
       super
-      self.name    = 'lolsrv'
-      self.default = false  
-      self.options << SERVER
-
+      self.options << 'server'
+      if self.runner
+        @logger = Logger.new(File.new(self.runner.config.loldir + "/lolsrv.log", "a+"))
+      end
     end
 
     def run
-      
-      log_file = File.new(self.runner.config.loldir + "/lolsrv.log", "a+")
-      @logger = Logger.new(log_file)
-      
-      if configuration[SERVER].nil?
-        puts "Missing server configuration. Use lolcommits --config -p lolsrv"
-        return
-      end
+      return unless valid_configuration?
+      fork { sync() }
+    end
 
-      fork do
-        sync()
-      end
+    def is_configured?
+      !configuration["enabled"].nil? && configuration["server"]
     end
 
     def sync
       existing = get_existing_lols
       unless existing.nil?
         Dir.glob(self.runner.config.loldir + "/*.jpg") do |item|
-          next if item == '.' or item == '..'
+          next if item == "." or item == ".."
           # do work on real items
-          sha = File.basename(item, '.*')
-          unless existing.include?(sha) || sha == 'tmp_snapshot' 
+          sha = File.basename(item, ".*")
+          unless existing.include?(sha) || sha == "tmp_snapshot"
             upload(item, sha)
           end
         end
@@ -49,11 +40,10 @@ module Lolcommits
     def get_existing_lols
       begin
         lols = JSON.parse(
-        RestClient.get(configuration[SERVER] + '/lols'))
+        RestClient.get(configuration['server'] + "/lols"))
         lols.map { |lol| lol["sha"] }
-      rescue => error
-        @logger.info "Existing lols could not be retrieved with Error " + error.message
-        @logger.info error.backtrace
+      rescue => e
+        log_error(e, "ERROR: existing lols could not be retrieved #{e.class} - #{e.message}")
         return nil
       end
     end
@@ -61,13 +51,24 @@ module Lolcommits
     def upload(file, sha)
       begin
         RestClient.post(
-        configuration[SERVER] + '/uplol', 
-        :lol => File.new(file),
-        :sha => sha) 
-      rescue => error
-        @logger.info "Upload of LOL "+ sha + " failed with Error " + error.message
+          configuration["server"] + "/uplol",
+          :lol => File.new(file),
+          :sha => sha
+        )
+      rescue => e
+        log_error(e,"ERROR: Upload of lol #{sha} FAILED #{e.class} - #{e.message}")
         return
       end
+    end
+
+    def log_error(e, message)
+      debug message
+      @logger.info message
+      @logger.info e.backtrace
+    end
+
+    def self.name
+      "lolsrv"
     end
   end
 end

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -3,22 +3,21 @@ module Lolcommits
 
     def initialize(runner)
       super
-
       @font_location = runner ? runner.font : nil
+    end
 
-      self.name    = 'loltext'
-      self.default = true
+    # enabled by default (if no configuration exists)
+    def is_enabled?
+      !is_configured? || super
     end
 
     def run
-      mm_run
-    end
+      font_location = @font_location || File.join(Configuration::LOLCOMMITS_ROOT,
+                                                  "vendor",
+                                                  "fonts",
+                                                  "Impact.ttf")
 
-    # use minimagick wrapper
-    def mm_run
-      font_location = @font_location || File.join(Configuration::LOLCOMMITS_ROOT, "vendor", "fonts", "Impact.ttf")
-
-      plugdebug "Annotating image via MiniMagick"
+      debug "Annotating image via MiniMagick"
       image = MiniMagick::Image.open(self.runner.main_image)
       image.combine_options do |c|
         c.gravity 'SouthWest'
@@ -41,34 +40,14 @@ module Lolcommits
         c.annotate '0', self.runner.sha
       end
 
-      plugdebug "Writing changed file to #{self.runner.main_image}"
+      debug "Writing changed file to #{self.runner.main_image}"
       image.write self.runner.main_image
     end
 
-    # use Rmagick wrapper (deprecated, no longer works in IM6.10+)
-    # def rm_run
-    #   canvas = ImageList.new(self.runner.main_image)
-    #   draw = Magick::Draw.new
-    #   draw.font = File.join(Configuration::LOLCOMMITS_ROOT, "vendor", "fonts", "Impact.ttf")
+    def self.name
+     'loltext'
+    end
 
-    #   draw.fill   = 'white'
-    #   draw.stroke = 'black'
-
-    #   draw.annotate(canvas, 0, 0, 0, 0, self.runner.sha) do
-    #     self.gravity = NorthEastGravity
-    #     self.pointsize = 32
-    #     self.stroke_width = 2
-    #   end
-
-    #   draw.annotate(canvas, 0, 0, 0, 0, word_wrap(self.runner.message)) do
-    #     self.gravity = SouthWestGravity
-    #     self.pointsize = 48
-    #     self.interline_spacing = -(48 / 5) if self.respond_to?(:interline_spacing)
-    #     self.stroke_width = 2
-    #   end
-
-    #   canvas.write(runner.main_image)
-    # end
 
     private
 

--- a/lib/lolcommits/plugins/tranzlate.rb
+++ b/lib/lolcommits/plugins/tranzlate.rb
@@ -100,17 +100,14 @@ module Lolcommits
 
     extend Lolspeak
 
-    def initialize(runner)
-      super
-
-      self.name    = 'tranzlate'
-      self.default = false
+    def run
+      debug "Commit message before: #{self.runner.message}"
+      self.runner.message = self.class.tranzlate(self.runner.message)
+      debug "Commit message after: #{self.runner.message}"
     end
 
-    def run
-      plugdebug "Commit message before: #{self.runner.message}"
-      self.runner.message = self.class.tranzlate(self.runner.message)
-      plugdebug "Commit message after: #{self.runner.message}"
+    def self.name
+      'tranzlate'
     end
   end
 end

--- a/lib/lolcommits/plugins/uploldz.rb
+++ b/lib/lolcommits/plugins/uploldz.rb
@@ -6,25 +6,29 @@ module Lolcommits
 
     def initialize(runner)
       super
-
-      self.name     = 'uploldz'
-      self.default  = false
-      self.options.concat(['endpoint'])
+      self.options << 'endpoint'
     end
 
     def run
+      return unless valid_configuration?
+
       repo = self.runner.repo.to_s
-      if configuration['endpoint'].empty?
-        puts "Endpoint URL is empty, please run lolcommits --config to add one."
-      elsif repo.empty?
+      if repo.empty?
         puts "Repo is empty, skipping upload"
       else
-        plugdebug "Calling " + configuration['endpoint'] + " with repo " + repo
-        RestClient.post(configuration['endpoint'], 
+        debug "Calling " + configuration['endpoint'] + " with repo " + repo
+        RestClient.post(configuration['endpoint'],
           :file => File.new(self.runner.main_image),
           :repo => repo)
       end
+    end
 
+    def is_configured?
+      !configuration["enabled"].nil? && configuration["endpoint"]
+    end
+
+    def self.name
+      'uploldz'
     end
   end
 end

--- a/test/test_lolcommits.rb
+++ b/test/test_lolcommits.rb
@@ -9,21 +9,36 @@ include Lolcommits
 
 class LolTest < Test::Unit::TestCase
     def test_can_parse_git
-        assert_nothing_raised do
-            gi = GitInfo.new
-            assert_not_nil gi.message
-            assert_not_nil gi.sha
-        end
+      assert_nothing_raised do
+        gi = GitInfo.new
+        assert_not_nil gi.message
+        assert_not_nil gi.sha
+      end
     end
 
     #
     # issue #57, https://github.com/mroth/lolcommits/issues/57
     #
     def test_tranzlate
-        [["what the hell","(WH|W)UT TEH HELL"],["seriously wtf", "SRSLEH WTF"]].each do |normal, lol|
-            tranzlated = Lolcommits::Tranzlate.tranzlate(normal)
-            assert_match /^#{lol}/, tranzlated
-        end
+      [["what the hell","(WH|W)UT TEH HELL"],["seriously wtf", "SRSLEH WTF"]].each do |normal, lol|
+        tranzlated = Lolcommits::Tranzlate.tranzlate(normal)
+        assert_match /^#{lol}/, tranzlated
+      end
+    end
+
+    #
+    # issue #136, https://github.com/mroth/lolcommits/issues/136
+    def test_lol_twitter_build_tweet
+      long_commit_message = %q{I wanna run, I want to hide, I want to tear down
+the walls that hold me inside. I want to reach out, and touch the flame...
+Where the streets have no name.. ah ah ah.. I want to feel sunlight on my
+face... I see the dust clouds disappear, without a trace... I want to take
+shelter... from the poison rain...  where the streets have no name... oahhhhh
+where the streets have no name... where the streets have no name }.gsub("\n", ' ')
+
+      plugin = Lolcommits::LolTwitter.new(nil)
+      Lolcommits::LolTwitter.send(:define_method, :max_tweet_size, Proc.new { 116 })
+      assert_match 'I wanna run, I want to hide, I want to tear down the walls that hold me inside. I want to reach out, a... #lolcommits', plugin.build_tweet(long_commit_message)
     end
 
     #
@@ -31,22 +46,22 @@ class LolTest < Test::Unit::TestCase
     # this will test the permissions but only locally, important before building a gem package!
     #
     def test_permissions
-        impact_perms = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, "vendor", "fonts", "Impact.ttf")).mode & 0777
-        imagesnap_perms = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, "vendor", "ext", "imagesnap", "imagesnap")).mode & 0777
-        videosnap_perms = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, "vendor", "ext", "videosnap", "videosnap")).mode & 0777
-        assert impact_perms == 0644 || impact_perms == 0664,
-            "expected perms of 644/664 but instead got #{sprintf '%o', impact_perms}"
-        assert imagesnap_perms == 0755 || imagesnap_perms == 0775,
-            "expected perms of 755/775 but instead got #{sprintf '%o', imagesnap_perms}"
-        assert videosnap_perms == 0755 || videosnap_perms == 0775,
-            "expected perms of 755/775 but instead got #{sprintf '%o', videosnap_perms}"
+      impact_perms = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, "vendor", "fonts", "Impact.ttf")).mode & 0777
+      imagesnap_perms = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, "vendor", "ext", "imagesnap", "imagesnap")).mode & 0777
+      videosnap_perms = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, "vendor", "ext", "videosnap", "videosnap")).mode & 0777
+      assert impact_perms == 0644 || impact_perms == 0664,
+        "expected perms of 644/664 but instead got #{sprintf '%o', impact_perms}"
+      assert imagesnap_perms == 0755 || imagesnap_perms == 0775,
+        "expected perms of 755/775 but instead got #{sprintf '%o', imagesnap_perms}"
+      assert videosnap_perms == 0755 || videosnap_perms == 0775,
+        "expected perms of 755/775 but instead got #{sprintf '%o', videosnap_perms}"
     end
 
     # Hmm.. webcam capture breaks travis-ci tests
     #def test_can_capture
-    #    assert_nothing_raised do
-    #        Lolcommits.capture(0,true,'test commit message','test-sha-001')
-    #    end
+    #  assert_nothing_raised do
+    #    Lolcommits.capture(0,true,'test commit message','test-sha-001')
+    #  end
     #end
 
 end


### PR DESCRIPTION
This PR refactors the plugin code and plugin configuration.  It also adds fixes for issues #73 and #136.
Here is a summary of all the changes, check the diff for more details.
### Lolcommits::Configuration

Refactored with (smaller) methods for:
- `ask_for_plugin_name` added to grab user input
- `find_plugin` finds plugin by name, returns new plugin object (with nil runner)
- `do_configure!` now delegates to each plugin's own `configure_options!` method
- `save` simply writes the config file to disk
- `to_s` now returns the config yaml file to a string
### Lolcommits::Plugin

The base plugin class now has a basic method for `configure_options!` that can be
overridden in each plugin sub class. The following methods were added or changed:
- `is_enabled?` and `is_configured?` methods now exist that can be used in plugins
- `puts` was overidden so that plugin output respects the lolcommits `stealth` option
- `plugdebug` was renamed to simply `debug`, and postfixes the plugin name in debug calls
- `self.name` is a new class method that defines the plugins name (used in config/listing/finding plugins etc.)
- `valid_configuration?` checks for a valid config, shows error if its missing

After these changes it was nesecary to refactor the existing plugins to work.
Most of the changes are minor, adding `is_configured?` and `self.name` methods.
- `lolsrv` got better logging and error handling methods
- Removed a bunch of old commented out code from the `loltext` plugin
- `lol_twitter` had a bigger set of changes (see below)
### Lolcommits::LolTwitter

The main change here was tho have configuration happening through the regular method, via:

```
 lolcommits --config -p twitter
```

This resolves issue #73, and the configuration code now handles errors better and checks
for a valid PIN before proceeding. Issue #136 should also be resolved now too so tweet messages are properly truncated (test added)
