### PR TITLE
Allow lolsrv plugin to upload gifs & jpgs

### DIFF
--- a/lib/lolcommits/plugins/lolsrv.rb
+++ b/lib/lolcommits/plugins/lolsrv.rb
@@ -26,9 +26,7 @@ module Lolcommits
     def sync
       existing = get_existing_lols
       unless existing.nil?
-        Dir.glob(self.runner.config.loldir + "/*.jpg") do |item|
-          next if item == "." or item == ".."
-          # do work on real items
+        Dir[self.runner.config.loldir + "/*.{jpg,gif}"].each do |item|
           sha = File.basename(item, ".*")
           unless existing.include?(sha) || sha == "tmp_snapshot"
             upload(item, sha)


### PR DESCRIPTION
A simple tiny change to allow lolsrv plugin to also upload **gif** images (can be created via animated lolcommits).  I also cleaned up some wierd indenting in this plugin class.
