### PR TITLE
adding `--devices` option (mac only) to list attached video devices

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 0.x.x (in development)
   * TODO: figure out problems with GUI clients
+  * Added `--devices` option, mac only for now (@matthutchinson #183, #174)
 
 0.5.2 (5 December 2013)
   * Allow lolsrv plugin to sync/upload gifs (@matthutchinson #180)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Or they can be set via the following arguments in the capture command (located i
 * `--fork`
 * `--stealth`
 
-Read how to [configure commit capturing](https://github.com/mroth/lolcommits/wiki/Configure-Commit-Capturing) for more details.
+Use `lolcommits --devices` to list all attached video devices available for capturing. Read how to [configure commit capturing](https://github.com/mroth/lolcommits/wiki/Configure-Commit-Capturing) for more details.
 
 ### Animated Gif Capturing
 Animated gifs (Mac/OSX only) can take a while to generate (depending on the number of seconds you capture and the capabilities of your machine). `ffmpeg` is required and can be installed with brew like so;

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -409,12 +409,17 @@ Choice.options do
 
   option :device do
     long "--device=DEVICE"
-    desc "the device name used to take the snapshot (only mac/linux)"
+    desc "the device name used to take the snapshot (mac/linux only)"
+  end
+
+  option :devices do
+    long "--devices"
+    desc "list all video devices available (mac only)"
   end
 
   option :debug do
     long "--debug"
-    desc "Output debugging information"
+    desc "output debugging information"
   end
 
   option :font do
@@ -473,6 +478,8 @@ if not (Choice.choices[:enable] || Choice.choices[:disable])
     puts configuration
   elsif Choice.choices[:plugins]
     configuration.puts_plugins()
+  elsif Choice.choices[:devices]
+    configuration.puts_devices()
   elsif Choice.choices[:last]
     do_last()
   elsif Choice.choices[:browse]

--- a/lib/lolcommits/capture_cygwin.rb
+++ b/lib/lolcommits/capture_cygwin.rb
@@ -1,7 +1,7 @@
 module Lolcommits
   class CaptureCygwin < Capturer
+
     def capture
-      commandcam_exe = File.join Configuration::LOLCOMMITS_ROOT, "vendor", "ext", "CommandCam", "CommandCam.exe"
       # DirectShow takes a while to show... at least for me anyway
       delaycmd = " /delay 3000"
       if capture_delay > 0
@@ -9,12 +9,14 @@ module Lolcommits
         delaycmd = " /delay #{capture_delay * 1000}"
       end
 
-      _, r, _ = Open3.popen3("#{commandcam_exe} /filename `cygpath -w #{snapshot_location}`#{delaycmd}")
+      _, r, _ = Open3.popen3("#{executable_path} /filename `cygpath -w #{snapshot_location}`#{delaycmd}")
 
       # looks like we still need to read the output for something to happen
       r.read
     end
 
+    def executable_path
+      File.join(Configuration::LOLCOMMITS_ROOT, "vendor", "ext", "CommandCam", "CommandCam.exe")
+    end
   end
-
 end

--- a/lib/lolcommits/capture_fake.rb
+++ b/lib/lolcommits/capture_fake.rb
@@ -1,10 +1,9 @@
 module Lolcommits
   class CaptureFake < Capturer
+
     def capture
       test_image = File.join Configuration::LOLCOMMITS_ROOT, "test", "images", "test_image.jpg"
       FileUtils.cp test_image, snapshot_location
     end
-
   end
 end
-

--- a/lib/lolcommits/capture_linux.rb
+++ b/lib/lolcommits/capture_linux.rb
@@ -1,5 +1,6 @@
 module Lolcommits
   class CaptureLinux < Capturer
+
     def capture_device_string
       @capture_device.nil? ? nil : "-tv device=\"#{@capture_device}\""
     end
@@ -18,7 +19,7 @@ module Lolcommits
 
       debug "LinuxCapturer: calling out to mplayer to capture image"
       # mplayer's output is ugly and useless, let's throw it away
-      _, r, _ = Open3.popen3("mplayer -vo jpeg:outdir=#{tmpdir} #{capture_device_string} -frames #{frames} tv://")
+      _, r, _ = Open3.popen3("#{executable_path} -vo jpeg:outdir=#{tmpdir} #{capture_device_string} -frames #{frames} tv://")
       # looks like we still need to read the output for something to happen
       r.read
 
@@ -31,6 +32,8 @@ module Lolcommits
       FileUtils.rm_rf( tmpdir )
     end
 
+    def executable_path
+      "mplayer"
+    end
   end
-
 end

--- a/lib/lolcommits/capture_mac.rb
+++ b/lib/lolcommits/capture_mac.rb
@@ -1,18 +1,17 @@
 module Lolcommits
   class CaptureMac < Capturer
+
     def capture_device_string
       @capture_device.nil? ? nil : "-d \"#{@capture_device}\""
     end
 
     def capture
-      call_str = "#{imagesnap_bin} -q \"#{snapshot_location}\" -w #{capture_delay} #{capture_device_string}"
+      call_str = "#{executable_path} -q \"#{snapshot_location}\" -w #{capture_delay} #{capture_device_string}"
       debug "Capturer: making system call for #{call_str}"
       system(call_str)
     end
 
-    private
-
-    def imagesnap_bin
+    def executable_path
       File.join(Configuration::LOLCOMMITS_ROOT, "vendor", "ext", "imagesnap", "imagesnap")
     end
   end

--- a/lib/lolcommits/capture_mac_animated.rb
+++ b/lib/lolcommits/capture_mac_animated.rb
@@ -7,7 +7,7 @@ module Lolcommits
       FileUtils.mkdir_p(frames_location)
 
       # capture the raw video with videosnap
-      system_call "#{videosnap_bin} -s 240 #{capture_device_string}#{capture_delay_string}-t #{animated_duration} --no-audio #{video_location} > /dev/null"
+      system_call "#{executable_path} -s 240 #{capture_device_string}#{capture_delay_string}-t #{animated_duration} --no-audio #{video_location} > /dev/null"
       if File.exists?(video_location)
         # convert raw video to png frames with ffmpeg
         system_call "ffmpeg -v quiet -i #{video_location} -t #{animated_duration} #{frames_location}/%09d.png"
@@ -25,7 +25,12 @@ module Lolcommits
       end
     end
 
+    def executable_path
+      File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'ext', 'videosnap', 'videosnap')
+    end
+
     private
+
     def system_call(call_str, capture_output = false)
       debug "Capturer: making system call for \n #{call_str}"
       capture_output ? `#{call_str}` : system(call_str)
@@ -55,10 +60,6 @@ module Lolcommits
       end
     end
 
-    def videosnap_bin
-      File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'ext', 'videosnap', 'videosnap')
-    end
-
     def capture_device_string
       "-d '#{capture_device}' " if capture_device
     end
@@ -66,6 +67,5 @@ module Lolcommits
     def capture_delay_string
       "-w '#{capture_delay}' " if capture_delay.to_i > 0
     end
-
   end
 end

--- a/lib/lolcommits/capture_windows.rb
+++ b/lib/lolcommits/capture_windows.rb
@@ -1,7 +1,7 @@
 module Lolcommits
   class CaptureWindows < Capturer
+
     def capture
-      commandcam_exe = File.join Configuration::LOLCOMMITS_ROOT, "vendor", "ext", "CommandCam", "CommandCam.exe"
       # DirectShow takes a while to show... at least for me anyway
       delaycmd = " /delay 3000"
       if capture_delay > 0
@@ -9,12 +9,14 @@ module Lolcommits
         delaycmd = " /delay #{capture_delay * 1000}"
       end
 
-      _, r, _ = Open3.popen3("#{commandcam_exe} /filename #{snapshot_location}#{delaycmd}")
+      _, r, _ = Open3.popen3("#{executable_path} /filename #{snapshot_location}#{delaycmd}")
 
       # looks like we still need to read the output for something to happen
       r.read
     end
 
+    def executable_path
+      File.join(Configuration::LOLCOMMITS_ROOT, "vendor", "ext", "CommandCam", "CommandCam.exe")
+    end
   end
-
 end

--- a/lib/lolcommits/capturer.rb
+++ b/lib/lolcommits/capturer.rb
@@ -1,6 +1,8 @@
 module Lolcommits
   class Capturer
+
     include Methadone::CLILogging
+
     attr_accessor :capture_device, :capture_delay, :snapshot_location, :font,
                   :video_location, :frames_location, :animated_duration
 

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -10,24 +10,6 @@ module Lolcommits
       end
     end
 
-    def self.platform
-      if is_fakeplatform?
-        ENV['LOLCOMMITS_FAKEPLATFORM']
-      elsif is_fakecapture?
-        'Fake'
-      elsif is_mac?
-        'Mac'
-      elsif is_linux?
-        'Linux'
-      elsif is_windows?
-        'Windows'
-      elsif is_cygwin?
-        'Cygwin'
-      else
-        raise "Unknown / Unsupported Platform."
-      end
-    end
-
     def read_configuration
       if File.exists?(configuration_file)
         YAML.load(File.open(configuration_file))
@@ -57,15 +39,6 @@ module Lolcommits
       dir
     end
 
-    def self.loldir_for(basename)
-      loldir = File.join(LOLBASEDIR, basename)
-
-      if not File.directory? loldir
-        FileUtils.mkdir_p loldir
-      end
-      loldir
-    end
-
     def most_recent
       Dir.glob(File.join self.loldir, "*.jpg").max_by {|f| File.mtime(f)}
     end
@@ -92,6 +65,15 @@ module Lolcommits
 
     def frames_loc
       File.join(self.loldir, 'tmp_frames')
+    end
+
+    def puts_devices
+      # TODO: handle other platforms here (linux/windows)
+      if self.class.is_mac?
+        capturer = Lolcommits::CaptureMacAnimated.new
+        puts `#{capturer.executable_path} -l`
+        puts "Specify a device with --device=\"{device name}\" or set the LOLCOMMITS_DEVICE env variable"
+      end
     end
 
     def puts_plugins
@@ -145,6 +127,36 @@ module Lolcommits
 
     def to_s
       read_configuration.to_yaml.to_s
+    end
+
+
+    # class methods
+
+    def self.platform
+      if is_fakeplatform?
+        ENV['LOLCOMMITS_FAKEPLATFORM']
+      elsif is_fakecapture?
+        'Fake'
+      elsif is_mac?
+        'Mac'
+      elsif is_linux?
+        'Linux'
+      elsif is_windows?
+        'Windows'
+      elsif is_cygwin?
+        'Cygwin'
+      else
+        raise "Unknown / Unsupported Platform."
+      end
+    end
+
+    def self.loldir_for(basename)
+      loldir = File.join(LOLBASEDIR, basename)
+
+      if not File.directory? loldir
+        FileUtils.mkdir_p loldir
+      end
+      loldir
     end
 
     def self.is_mac?


### PR DESCRIPTION
- mac-only for now (outputs nothing on other platforms)
- some tidy-up in all capture classes (introduction of a common `executable_path` method)
- in a future PR, i'll handle this option on linux (maybe with something like [this](http://stackoverflow.com/questions/4290834/how-to-get-a-list-of-video-capture-devices-web-cameras-on-linux-ubuntu-c)
- README and CHANGLOG updated
- tests passing and :green_heart: 

after merging, we can probably close #183 and #174, and i'll update this [wiki page](https://github.com/mroth/lolcommits/wiki/Configure-Commit-Capturing) with info on the `--devices` option
