### PR TITLE
[fix] lolsrv plugin should use debug method

### DIFF
--- a/lib/lolcommits/plugins/lolsrv.rb
+++ b/lib/lolcommits/plugins/lolsrv.rb
@@ -2,16 +2,12 @@
 require 'rest_client'
 require 'pp'
 require 'json'
-require 'logger'
 
 module Lolcommits
   class Lolsrv < Plugin
     def initialize(runner)
       super
       self.options << 'server'
-      if self.runner
-        @logger = Logger.new(File.new(self.runner.config.loldir + '/lolsrv.log', 'a+'))
-      end
     end
 
     def run
@@ -63,8 +59,7 @@ module Lolcommits
 
     def log_error(e, message)
       debug message
-      @logger.info message
-      @logger.info e.backtrace
+      debug e.backtrace
     end
 
     def self.name


### PR DESCRIPTION
Also means we dont have an lolsrv.log file anymore (which was being created whether you had the plugin enabled or not)

If you need to debug things and see log output, use the `--debug` command argument on `lolcommit` calls.
