### PR TITLE
Badges redux in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Git blame has never been so much fun.
 
 By default, the lolimages are stored by a Github style short SHA in a `~/.lolcommits` directory created for you.
 
-[![Gem Version](http://img.shields.io/gem/v/lolcommits.svg)](https://rubygems.org/gems/lolcommits)
-[![Build Status](http://img.shields.io/travis/mroth/lolcommits.svg)](https://travis-ci.org/mroth/lolcommits)
-[![Dependency Status](http://img.shields.io/gemnasium/mroth/lolcommits.svg)](https://gemnasium.com/mroth/lolcommits)
-[![CodeClimate Status](http://img.shields.io/codeclimate/github/mroth/lolcommits.svg)](https://codeclimate.com/github/mroth/lolcommits)
-[![Coverage Status](http://img.shields.io/coveralls/mroth/lolcommits.svg)](https://coveralls.io/r/mroth/lolcommits)
+[![Gem Version](http://img.shields.io/gem/v/lolcommits.svg?style=flat)](https://rubygems.org/gems/lolcommits)
+[![Build Status](http://img.shields.io/travis/mroth/lolcommits.svg?style=flat)](https://travis-ci.org/mroth/lolcommits)
+[![Dependency Status](http://img.shields.io/gemnasium/mroth/lolcommits.svg?style=flat)](https://gemnasium.com/mroth/lolcommits)
+[![CodeClimate Status](http://img.shields.io/codeclimate/github/mroth/lolcommits.svg?style=flat)](https://codeclimate.com/github/mroth/lolcommits)
+[![Coverage Status](http://img.shields.io/coveralls/mroth/lolcommits.svg?style=flat)](https://coveralls.io/r/mroth/lolcommits)
 
 ## Sample images
 <img src="http://blog.mroth.info/images/postcontent/yearinsideprojects/lolcommits_users2.jpg" />


### PR DESCRIPTION
The least important thing possible to be working on, but this is what happens when I get a piece of hardware with a retina display apparently!

Switch to Shields.IO for README badge generation, resulting in badges that are pretty, uniform, small file size, and resolution independent.
