### PR TITLE
Send file as base64 encoded over HTTP Post

### DIFF
--- a/lib/lolcommits/plugins/uploldz.rb
+++ b/lib/lolcommits/plugins/uploldz.rb
@@ -1,5 +1,6 @@
 # -*- encoding : utf-8 -*-
 require 'rest_client'
+require 'base64'
 
 module Lolcommits
   class Uploldz < Plugin
@@ -19,7 +20,7 @@ module Lolcommits
       else
         debug 'Calling ' + configuration['endpoint'] + ' with repo ' + repo
         RestClient.post(configuration['endpoint'],
-                        :file => File.new(self.runner.main_image),
+                        :file => Base64.encode64(File.read(self.runner.main_image)),
                         :repo => repo,
                         :key => configuration['optional_key'])
       end
@@ -34,7 +35,6 @@ module Lolcommits
     def self.name
       'uploldz'
     end
-
     def self.runner_order
       :postcapture
     end


### PR DESCRIPTION
Uploldz did not work correctly for me, since it was attempting to send a file resource instead of actual data, and the raw data is binary, so I base64'd it.
