### PR TITLE
--last includes animated gifs, fixes issue #213

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -170,10 +170,10 @@ def do_gif
 
   case Choice.choices[:gif]
     when 'today'
-      lolimages = configuration.images_today
+      lolimages = configuration.jpg_images_today
       filename  = "#{Date.today.to_s}.gif"
     else
-      lolimages = configuration.images
+      lolimages = configuration.jpg_images
       filename  = 'archive.gif'
   end
 

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -41,15 +41,15 @@ module Lolcommits
     end
 
     def most_recent
-      Dir.glob(File.join self.loldir, '*.jpg').max_by { |f| File.mtime(f) }
+      Dir.glob(File.join self.loldir, '*.{jpg,gif}').max_by { |f| File.mtime(f) }
     end
 
-    def images
+    def jpg_images
       Dir.glob(File.join self.loldir, '*.jpg').sort_by { |f| File.mtime(f) }
     end
 
-    def images_today
-      images.select { |f| Date.parse(File.mtime(f).to_s) === Date.today }
+    def jpg_images_today
+      jpg_images.select { |f| Date.parse(File.mtime(f).to_s) === Date.today }
     end
 
     def raw_image(image_file_type = 'jpg')


### PR DESCRIPTION
Small PR to fix #213 the `--last` option should always include gif's.

Also tidied the method names for generating an animated archive gif, which should only operate on jpegs for input.
