### PR TITLE
Added: added feature to no have text on the taken picture

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ lolcommits has some capture options for additional lulz. You can enable these vi
 * `LOLCOMMITS_FONT` set font file location for lolcommit text
 * `LOLCOMMITS_FORK` fork lolcommit runner (capture command forks to a new process, speedily returning you to your terminal)
 * `LOLCOMMITS_STEALTH` disable notification messages at commit time
+* `LOLCOMMITS_NOTEXT` disable the lolcommit text
 
 Or they can be set via the following arguments in the capture command (located in your repository's `.git/hooks/post-commit` file).
 
@@ -75,6 +76,7 @@ Or they can be set via the following arguments in the capture command (located i
 * `--font=FONT_PATH` or `-f FONT_PATH`
 * `--fork`
 * `--stealth`
+* `--no-text`
 
 Use `lolcommits --devices` to list all attached video devices available for capturing. Read how to [configure commit capturing](https://github.com/mroth/lolcommits/wiki/Configure-Commit-Capturing) for more details.
 

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -95,6 +95,7 @@ def do_capture
   capture_stealth = Choice.choices[:stealth]  || ENV['LOLCOMMITS_STEALTH']  || nil
   capture_device  = Choice.choices[:device]   || ENV['LOLCOMMITS_DEVICE']   || nil
   capture_font    = Choice.choices[:font]     || ENV['LOLCOMMITS_FONT']     || nil
+  capture_text    = !(Choice.choices[:no_text] || ENV['LOLCOMMITS_NOTEXT']) && true
 
   capture_options = {
     :capture_delay   => capture_delay,
@@ -102,7 +103,8 @@ def do_capture
     :capture_device  => capture_device,
     :font            => capture_font,
     :capture_animate => capture_animate,
-    :config          => configuration
+    :config          => configuration,
+    :capture_text    => capture_text
   }
 
   fork_me? do
@@ -305,6 +307,11 @@ Choice.options do
   option :stealth do
     long '--stealth'
     desc 'capture image in stealth mode'
+  end
+
+  option :no_text do
+    long '--no-text'
+    desc 'capture image without information text'
   end
 
   option :device do

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -5,7 +5,7 @@ module Lolcommits
   class Runner
     attr_accessor :capture_delay, :capture_stealth, :capture_device, :message, :sha,
                   :snapshot_loc, :main_image, :repo, :config, :repo_internal_path,
-                  :font, :capture_animate, :url
+                  :font, :capture_animate, :url, :capture_text
 
     include Methadone::CLILogging
 
@@ -44,7 +44,10 @@ module Lolcommits
       # do native plugins that need to happen immediately after capture
       # this is effectively the "image processing" phase
       # for now, reserve just for us and handle manually...?
-      Lolcommits::Loltext.new(self).execute_postcapture
+
+      if self.capture_text
+        Lolcommits::Loltext.new(self).execute_postcapture
+      end
 
       # do native plugins that need to happen after capture
       plugins_for(:postcapture).each do |plugin|


### PR DESCRIPTION
Previously, it wasn't possible to take a picture without the commit text.
Now we can, this is possible with the option --no-text ot the environment variable LOLCOMMITS_NOTEXT

Fixed #187
