### PR TITLE
Update travis-ci to test against ruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ before_install:
  - gem update --system 2.1.11
  - gem --version
  - sudo apt-get update -qq
- - sudo apt-get install -qq -y mplayer
- - sudo apt-get install ffmpeg
+ - sudo apt-get install -qq -y mplayer ffmpeg
  # imagemagick is installed by default on normal travis image now
  # - sudo apt-get install -qq -y imagemagick libmagickwand-dev
 


### PR DESCRIPTION
Ruby 2.2 isn’t that far off so we should know about potential breaks beforehand.
