### PR TITLE
Better error msg when ImageMagick install can't be found or broken

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 0.5.6 (in development)
+  * Improved error message when ImageMagick install has issues #159
   * Fix twitter plugin config issue #231
   * update gems!
   * prepare plugins for extraction

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -79,8 +79,7 @@ Feature: Basic UI functionality
     When I successfully run `lolcommits --capture --fork`
     Then there should be exactly 1 pid in "../.lolcommits/testforkcapture"
     When I wait for the child process to exit in "testforkcapture"
-    Then the output should contain "*** Preserving this moment in history."
-      And a directory named "../.lolcommits/testforkcapture" should exist
+    Then a directory named "../.lolcommits/testforkcapture" should exist
       And a file named "../.lolcommits/testforkcapture/tmp_snapshot.jpg" should not exist
       And there should be exactly 1 jpg in "../.lolcommits/testforkcapture"
 

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -198,6 +198,11 @@ module Lolcommits
       # you'd expect the below to work on its own, but it only handles old versions
       # and will throw an exception if IM is not installed in PATH
       MiniMagick.valid_version_installed?
+    rescue
+      puts "FATAL: ImageMagick >= #{MiniMagick.minimum_image_magick_version} required (http://imagemagick.org)"
+      puts 'Please check the following command works and returns a valid version number'
+      puts '=> mogrify --version'
+      exit 1
     end
 
     def self.valid_ffmpeg_installed?

--- a/rubocop-todo.yml
+++ b/rubocop-todo.yml
@@ -66,7 +66,7 @@ Documentation:
 # Offence count: 3
 # Configuration parameters: CountComments.
 ClassLength:
-  Max: 179
+  Max: 190
 
 # Offence count: 73
 LineLength:


### PR DESCRIPTION
- Closes issue #159 

Stemming from issue #159, decided it would be worth explaining that ImageMagick is either missing, wrong version, or suffering from a broken install at this point. The `mogrify --version` command should work and is a dependency for this gem.
