### PR TITLE
Update readme.md to include ffmpeg installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Install dependencies using your package manager of choice, for example in
 Ubuntu:
 
     sudo apt-get install mplayer imagemagick libmagickwand-dev
+    
+For Ubuntu 14.04 or newer, you need to manually install ffmpeg since it no longer ships with the default Ubuntu sources. [Downloads for ffmpeg](http://ffmpeg.org/download.html)
 
 Then install the gem with:
 


### PR DESCRIPTION
On Ubuntu 14.04 or newer, users needs to manually install ffmpeg. This commit adds those instructions to the readme.
