### PR TITLE
add LANG to post commit hook to resolve locale issues with clients

### DIFF
--- a/lib/lolcommits/installation.rb
+++ b/lib/lolcommits/installation.rb
@@ -75,15 +75,16 @@ module Lolcommits
     protected
 
     def self.hook_script(add_shebang = true)
-      ruby_path    = Lolcommits::Configuration.command_which('ruby', true)
-      imagick_path = Lolcommits::Configuration.command_which('identify', true)
-      hook_export  = "export PATH=\"#{ruby_path}:#{imagick_path}:$PATH\"\n"
-      capture_cmd  = 'lolcommits --capture'
-      capture_args = " #{ARGV[1..-1].join(' ')}" if ARGV.length > 1
+      ruby_path     = Lolcommits::Configuration.command_which('ruby', true)
+      imagick_path  = Lolcommits::Configuration.command_which('identify', true)
+      locale_export = "export LANG=\"#{ENV['LANG']}\"\n"
+      hook_export   = "export PATH=\"#{ruby_path}:#{imagick_path}:$PATH\"\n"
+      capture_cmd   = 'lolcommits --capture'
+      capture_args  = " #{ARGV[1..-1].join(' ')}" if ARGV.length > 1
 
       <<-EOS
 ### lolcommits hook (begin) ###
-#{hook_export}#{capture_cmd}#{capture_args}
+#{locale_export}#{hook_export}#{capture_cmd}#{capture_args}
 ###  lolcommits hook (end)  ###
 EOS
     end


### PR DESCRIPTION
Hotfix commit/PR to resolve issues with GitHub for Mac client on Yosemite.

For some reason this GitHub app is now failing to have the current user's `LANG` env var set when it runs its hooks.

This closes issue #239
