### PR TITLE
Allow runner to hold the git_info object so plugins can make use of it

### DIFF
--- a/lib/lolcommits/git_info.rb
+++ b/lib/lolcommits/git_info.rb
@@ -2,11 +2,10 @@
 module Lolcommits
   class GitInfo
     include Methadone::CLILogging
-    attr_accessor :sha, :message, :repo_internal_path, :repo, :url
+    attr_accessor :sha, :message, :repo_internal_path, :repo, :url,
+                  :author_name, :author_email
 
-    def remote_https_url(url)
-      url.gsub(':', '/').gsub(/^git@/, 'https://').gsub(/\.git$/, '') + '/commit/'
-    end
+    GIT_URL_REGEX = /.*[:]([\/\w\-]*).git/
 
     def initialize
       debug 'GitInfo: attempting to read local repository'
@@ -18,21 +17,36 @@ module Lolcommits
       self.message = commit.message.split("\n").first
       self.sha     = commit.sha[0..10]
       self.repo_internal_path = g.repo.path
-      self.url = remote_https_url(g.remote.url) if g.remote.url
 
-      regex = /.*[:]([\/\w\-]*).git/
-      match = g.remote.url.match regex if g.remote.url
+      if g.remote.url
+        self.url = remote_https_url(g.remote.url)
+        match = g.remote.url.match(GIT_URL_REGEX)
+      end
+
       if match
         self.repo = match[1]
       elsif !g.repo.path.empty?
         self.repo = g.repo.path.split(File::SEPARATOR)[-2]
       end
 
+      if commit.author
+        self.author_name = commit.author.name
+        self.author_email = commit.author.email
+      end
+
       debug 'GitInfo: parsed the following values from commit:'
-      debug "GitInfo: \t#{self.message}"
-      debug "GitInfo: \t#{self.sha}"
-      debug "GitInfo: \t#{self.repo_internal_path}"
-      debug "GitInfo: \t#{self.repo}"
+      debug "GitInfo: \t#{message}"
+      debug "GitInfo: \t#{sha}"
+      debug "GitInfo: \t#{repo_internal_path}"
+      debug "GitInfo: \t#{repo}"
+      debug "GitInfo: \t#{author_name}" if author_name
+      debug "GitInfo: \t#{author_email}" if author_email
+    end
+
+    private
+
+    def remote_https_url(url)
+      url.gsub(':', '/').gsub(/^git@/, 'https://').gsub(/\.git$/, '') + '/commit/'
     end
   end
 end

--- a/lib/lolcommits/plugins/lolsrv.rb
+++ b/lib/lolcommits/plugins/lolsrv.rb
@@ -42,11 +42,11 @@ module Lolcommits
 
     def upload(file, sha)
       RestClient.post(configuration['server'] + '/uplol',
-                      :lol => File.new(file),
-                      :url => self.runner.url + sha,
-                      :repo => self.runner.repo,
+                      :lol  => File.new(file),
+                      :url  => self.runner.git_info.url + sha,
+                      :repo => self.runner.git_info.repo,
                       :date => File.ctime(file),
-                      :sha => sha)
+                      :sha  => sha)
     rescue => e
       log_error(e, "ERROR: Upload of lol #{sha} FAILED #{e.class} - #{e.message}")
     end

--- a/lib/lolcommits/plugins/uploldz.rb
+++ b/lib/lolcommits/plugins/uploldz.rb
@@ -13,15 +13,18 @@ module Lolcommits
     def run_postcapture
       return unless valid_configuration?
 
-      repo = self.runner.repo.to_s
-      if repo.empty?
+      if self.runner.git_info.repo.empty?
         puts 'Repo is empty, skipping upload'
       else
-        debug 'Calling ' + configuration['endpoint'] + ' with repo ' + repo
+        debug "Posting capture to #{configuration['endpoint']}"
         RestClient.post(configuration['endpoint'],
-                        :file => File.new(self.runner.main_image),
-                        :repo => repo,
-                        :key => configuration['optional_key'])
+                        :file         => File.new(self.runner.main_image),
+                        :message      => self.runner.message,
+                        :repo         => self.runner.git_info.repo,
+                        :author_name  => self.runner.git_info.author_name,
+                        :author_email => self.runner.git_info.author_email,
+                        :sha          => self.runner.sha,
+                        :key          => configuration['optional_key'])
       end
     rescue => e
       log_error(e, "ERROR: RestClient POST FAILED #{e.class} - #{e.message}")

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -3,9 +3,9 @@ module Lolcommits
   PLUGINS = Lolcommits::Plugin.subclasses
 
   class Runner
-    attr_accessor :capture_delay, :capture_stealth, :capture_device, :message, :sha,
-                  :snapshot_loc, :main_image, :repo, :config, :repo_internal_path,
-                  :font, :capture_animate, :url
+    attr_accessor :capture_delay, :capture_stealth, :capture_device, :message,
+                  :sha, :snapshot_loc, :main_image, :config, :font, :git_info,
+                  :capture_animate
 
     include Methadone::CLILogging
 
@@ -15,12 +15,9 @@ module Lolcommits
       end
 
       if self.sha.nil? || self.message.nil?
-        git_info = GitInfo.new
-        self.sha = git_info.sha if self.sha.nil?
-        self.message = git_info.message if self.message.nil?
-        self.repo_internal_path = git_info.repo_internal_path
-        self.repo = git_info.repo
-        self.url  = git_info.url
+        self.git_info = GitInfo.new
+        self.sha      = git_info.sha if self.sha.nil?
+        self.message  = git_info.message if self.message.nil?
       end
     end
 
@@ -113,8 +110,8 @@ module Lolcommits
 
   def die_if_rebasing!
     debug "Runner: Making sure user isn't rebasing"
-    if not self.repo_internal_path.nil?
-      mergeclue = File.join self.repo_internal_path, 'rebase-merge'
+    if self.git_info && !self.git_info.repo_internal_path.nil?
+      mergeclue = File.join self.git_info.repo_internal_path, 'rebase-merge'
       if File.directory? mergeclue
         debug 'Runner: Rebase detected, silently exiting!'
         exit 0


### PR DESCRIPTION
Inspired by this PR to add some extra params to the uploldz plugin, i've made the `git_info` object available in the LolCommits::Runner class itself, so plugins can grab any info they like from it.

Also did some other small code clean ups in Runner and GitInfo classes.  I removed the following instance vars from the Runner class, in favour of getting these through the git_info object instead;

```
repo_internal_path
repo
url
```

I'll close #224 now in favour of this PR instead.  Thanks for you're contribution @clops!
