### PR TITLE
Adding prefix/suffix options to twitter plugin config

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 0.5.7 (WIP)
   * Uploldz plugin sends more post params (@clops #224 @matthutchinson #241)
-  * upgrade gems
-  * seperate gems for all plugins
+  * More configurable twitter plugin (@woodrowbarlow #207 @matthutchinson)
+  * Upgrade Twitter, Oauth and Json gems (@matthutchinson)
+  * wip .. upgrade all dependent gems
 
 0.5.6 (24 November 2014)
   * Updates and clean ups on the gemspec (@mroth #228)

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -49,13 +49,13 @@ Gem::Specification.new do |s|
   end
 
   # plugin dependencies
-  s.add_runtime_dependency('twitter', '~> 4.8.1')     #twitter
+  s.add_runtime_dependency('twitter', '~> 5.13.0')    #twitter
+  s.add_runtime_dependency('oauth', '~> 0.4.7')       #twitter oauth
   s.add_runtime_dependency('yam', '~> 2.0.1')         #yammer
-  s.add_runtime_dependency('oauth')                   #twitter
   s.add_runtime_dependency('rest-client')             #uploldz
   s.add_runtime_dependency('httmultiparty')           #dot_com
   s.add_runtime_dependency('httparty', "~> 0.11.0")   #dot_com
-  s.add_runtime_dependency('json', '~> 1.7.6')        #lolsrv
+  s.add_runtime_dependency('json', '~> 1.8.1')        #lolsrv
   s.add_runtime_dependency('mime-types', '~> 1.25')
 
 end

--- a/test/test_lolcommits.rb
+++ b/test/test_lolcommits.rb
@@ -45,6 +45,19 @@ where the streets have no name... where the streets have no name }.gsub("\n", ' 
     assert_match 'I wanna run, I want to hide, I want to tear down the walls that hold me inside. I want to reach out, a... #lolcommits', plugin.build_tweet(long_commit_message)
   end
 
+  def test_lol_twitter_prefix_suffix
+    plugin = Lolcommits::LolTwitter.new(nil)
+    Lolcommits::LolTwitter.send(:define_method, :max_tweet_size, Proc.new { 116 })
+    assert_match 'commit msg #lolcommits', plugin.build_tweet('commit msg')
+
+    plugin_config = {
+      'prefix' => '@prefixing!',
+      'suffix' => '#suffixing!'
+    }
+    Lolcommits::LolTwitter.send(:define_method, :configuration, Proc.new { plugin_config })
+    assert_match '@prefixing! commit msg #suffixing!', plugin.build_tweet('commit msg')
+  end
+
   #
   # issue #53, https://github.com/mroth/lolcommits/issues/53
   # this will test the permissions but only locally, important before building a gem package!


### PR DESCRIPTION
Based on @woodrowbarlow's PR #207 (now closed) - I have taken those changes and cleaned them up to provide a cleaner approach for configuring a prefix and a suffix for tweets sent from our twitter plugin. To summarise;

> The user will be prompted to specify an optional prefix or suffix (such as an `@user` and custom `#hashtag`) when enabling the twitter plugin. That information will be stored in the config.yml file.  If no suffix is supplied, a default hash tag, `#lolcommits` will always be added at the end of each tweet.

A new test was added to cover building tweets in this way.  I have also updated the twitter and json gems and set a specific gem version for oath `0.4.7`.  This was necessary to fix some oauth/token issues with the latest Twitter API.

Thanks to @woodrowbarlow for your initial contribution!

This PR closes #161 and will be released soon!
