### PR TITLE
Glob for default video device.

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -87,13 +87,23 @@ def capture_animate
   end
 end
 
+def default_device
+  result = Choice.choices[:device] || ENV['LOLCOMMITS_DEVICE']
+
+  if Configuration.platform_linux?
+    result ||= Dir.glob('/dev/video*').first
+  end
+
+  result
+end
+
 #
 # IF --CAPTURE, DO CAPTURE
 #
 def do_capture
   capture_delay   = Choice.choices[:delay]    || ENV['LOLCOMMITS_DELAY']    || 0
   capture_stealth = Choice.choices[:stealth]  || ENV['LOLCOMMITS_STEALTH']  || nil
-  capture_device  = Choice.choices[:device]   || ENV['LOLCOMMITS_DEVICE']   || nil
+  capture_device  = default_device
   capture_font    = Choice.choices[:font]     || ENV['LOLCOMMITS_FONT']     || nil
 
   capture_options = {


### PR DESCRIPTION
Hi, this adds a little tweak to look for other video devices than just `/dev/video0`, which is what mplayer does (on Linux at least).

If this should be changed to accommodate other systems (i.e. only using this on Linux or so) I'd be happy to do that.
