### PR TITLE
enable local plugins

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -219,6 +219,13 @@ def change_dir_to_root_or_repo!
   end
 end
 
+def load_local_plugins!
+  plugins_dir = Configuration.loldir_for('.plugins')
+  Dir.glob("#{plugins_dir}/*.rb").each do |plugin|
+    load plugin
+  end
+end
+
 #
 # Command line parsing fun
 #
@@ -374,6 +381,12 @@ die_on_fatal_conditions!
 # change working dir to either a repo or the fs root
 #
 change_dir_to_root_or_repo!
+
+#
+# load system local plugins
+#
+load_local_plugins!
+
 
 #
 # Handle actions manually since choice seems weird

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -74,7 +74,7 @@ module Lolcommits
     end
 
     def puts_plugins
-      puts "Available plugins: #{Lolcommits::PLUGINS.map(&:name).join(', ')}"
+      puts "Available plugins: #{Lolcommits::Runner.plugins.map(&:name).join(', ')}"
     end
 
     def ask_for_plugin_name
@@ -84,7 +84,7 @@ module Lolcommits
     end
 
     def find_plugin(plugin_name)
-      Lolcommits::PLUGINS.each do |plugin|
+      Lolcommits::Runner.plugins.each do |plugin|
         if plugin.name == plugin_name
           return plugin.new(nil)
         end

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -1,7 +1,5 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
-  PLUGINS = Lolcommits::Plugin.subclasses
-
   class Runner
     attr_accessor :capture_delay, :capture_stealth, :capture_device, :message,
                   :sha, :snapshot_loc, :main_image, :config, :font, :git_info,
@@ -69,7 +67,11 @@ module Lolcommits
     end
 
     def plugins_for(position)
-      Lolcommits::PLUGINS.select { |p| p.runner_order == position }
+      self.class.plugins.select { |p| p.runner_order == position }
+    end
+
+    def self.plugins
+      Lolcommits::Plugin.subclasses
     end
 
     # the main capture


### PR DESCRIPTION
This change will allow you to place plugins into $LOLCOMMITS_DIR/.plugins (typically: ~/.lolcommits/.plugins) for experimentation or to use plugins that are not yet merged into lolcommits. 

Every plugin placed into $LOLCOMMITS_DIR/.plugins has to implement the same interface as plugins shipped with lolcommits.