### PR TITLE
lolcommits plugin for protonet

### DIFF
--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -32,6 +32,7 @@ require 'lolcommits/plugins/lol_twitter'
 require 'lolcommits/plugins/uploldz'
 require 'lolcommits/plugins/lolsrv'
 require 'lolcommits/plugins/lol_yammer'
+require 'lolcommits/plugins/lol_protonet'
 
 # require runner after all the plugins have been required
 require 'lolcommits/runner'

--- a/lib/lolcommits/plugins/lol_protonet.rb
+++ b/lib/lolcommits/plugins/lol_protonet.rb
@@ -16,8 +16,7 @@ module Lolcommits
         api_url,
         {
           :files        => [File.new(self.runner.main_image)],
-          :message      => message,
-          :key          => configuration['optional_key']
+          :message      => message
         },
         {
           "X-Protonet-Token" => configuration['api_token']

--- a/lib/lolcommits/plugins/lol_protonet.rb
+++ b/lib/lolcommits/plugins/lol_protonet.rb
@@ -18,11 +18,8 @@ module Lolcommits
           :files        => [File.new(self.runner.main_image)],
           :message      => message
         },
-        {
-          "X-Protonet-Token" => configuration['api_token']
-        }
+        "X-Protonet-Token" => configuration['api_token']
       )
-
     end
 
     def api_url
@@ -34,24 +31,23 @@ module Lolcommits
     end
 
     def random_object
-      objects = [
-        'screws', 'bolts', 'exceptions', 'errors', 'cookies'
-      ]
+      objects = %w{'screws', 'bolts', 'exceptions', 'errors', 'cookies'}
 
       objects.sample
     end
 
     def random_adjective
-      adjectives = ["awesome", "great", "interesting", "cool", "EPIC", "gut", "good", "pansy",
-        "powerful", "boring", "quirky", "untested", "german", "iranian", "neutral", "crazy", "well tested",
-        "jimmy style", "nasty", "bibliographical (we received complaints about the original wording)", "bombdiggidy", "narly", "spiffy", "smashing", "xing style",
-        "leo apotheker style", "black", "white", "yellow", "shaggy", "tasty", "mind bending", "JAY-Z",
-        "Kanye (the best ever)", "* Toby Keith was here *", "splendid", "stupendulous",
-        "(freedom fries!)", "[vote RON PAUL]", "- these are not my glasses -", "typical pansy",
-        "- ze goggles zey do nothing! -", "almost working", "legen- wait for it -", "-dairy!",
-        " - Tavonius would be proud of this - ", "Meg FAILMAN!", "- very brofessional of you -",
-        "heartbleeding", "juciy", "supercalifragilisticexpialidocious", "failing", "loving"
-      ]
+      adjectives = %w{"awesome", "great", "interesting", "cool", "EPIC", "gut", "good", "pansy",
+                      "powerful", "boring", "quirky", "untested", "german", "iranian", "neutral", "crazy", "well tested",
+                      "jimmy style", "nasty", "bibliographical (we received complaints about the original wording)",
+                      "bombdiggidy", "narly", "spiffy", "smashing", "xing style",
+                      "leo apotheker style", "black", "white", "yellow", "shaggy", "tasty", "mind bending", "JAY-Z",
+                      "Kanye (the best ever)", "* Toby Keith was here *", "splendid", "stupendulous",
+                      "(freedom fries!)", "[vote RON PAUL]", "- these are not my glasses -", "typical pansy",
+                      "- ze goggles zey do nothing! -", "almost working", "legen- wait for it -", "-dairy!",
+                      " - Tavonius would be proud of this - ", "Meg FAILMAN!", "- very brofessional of you -",
+                      "heartbleeding", "juciy", "supercalifragilisticexpialidocious", "failing", "loving"
+                   }
       adjectives.sample
     end
 

--- a/lib/lolcommits/plugins/lol_protonet.rb
+++ b/lib/lolcommits/plugins/lol_protonet.rb
@@ -38,15 +38,15 @@ module Lolcommits
 
     def random_adjective
       adjectives = ["awesome", "great", "interesting", "cool", "EPIC", "gut", "good", "pansy",
-                      "powerful", "boring", "quirky", "untested", "german", "iranian", "neutral", "crazy", "well tested",
-                      "jimmy style", "nasty", "bibliographical (we received complaints about the original wording)",
-                      "bombdiggidy", "narly", "spiffy", "smashing", "xing style",
-                      "leo apotheker style", "black", "white", "yellow", "shaggy", "tasty", "mind bending", "JAY-Z",
-                      "Kanye (the best ever)", "* Toby Keith was here *", "splendid", "stupendulous",
-                      "(freedom fries!)", "[vote RON PAUL]", "- these are not my glasses -", "typical pansy",
-                      "- ze goggles zey do nothing! -", "almost working", "legen- wait for it -", "-dairy!",
-                      " - Tavonius would be proud of this - ", "Meg FAILMAN!", "- very brofessional of you -",
-                      "heartbleeding", "juciy", "supercalifragilisticexpialidocious", "failing", "loving"
+                    "powerful", "boring", "quirky", "untested", "german", "iranian", "neutral", "crazy", "well tested",
+                    "jimmy style", "nasty", "bibliographical (we received complaints about the original wording)",
+                    "bombdiggidy", "narly", "spiffy", "smashing", "xing style",
+                    "leo apotheker style", "black", "white", "yellow", "shaggy", "tasty", "mind bending", "JAY-Z",
+                    "Kanye (the best ever)", "* Toby Keith was here *", "splendid", "stupendulous",
+                    "(freedom fries!)", "[vote RON PAUL]", "- these are not my glasses -", "typical pansy",
+                    "- ze goggles zey do nothing! -", "almost working", "legen- wait for it -", "-dairy!",
+                    " - Tavonius would be proud of this - ", "Meg FAILMAN!", "- very brofessional of you -",
+                    "heartbleeding", "juciy", "supercalifragilisticexpialidocious", "failing", "loving"
                    ]
       adjectives.sample
     end

--- a/lib/lolcommits/plugins/lol_protonet.rb
+++ b/lib/lolcommits/plugins/lol_protonet.rb
@@ -31,7 +31,7 @@ module Lolcommits
     end
 
     def random_object
-      objects = %w{'screws', 'bolts', 'exceptions', 'errors', 'cookies'}
+      objects = %w{screws bolts exceptions errors cookies}
 
       objects.sample
     end

--- a/lib/lolcommits/plugins/lol_protonet.rb
+++ b/lib/lolcommits/plugins/lol_protonet.rb
@@ -1,0 +1,73 @@
+# -*- encoding : utf-8 -*-
+require 'rest_client'
+
+module Lolcommits
+  class LolProtonet < Plugin
+    def initialize(runner)
+      super
+      self.options.concat(['api_token', 'api_endpoint'])
+    end
+
+    def run_postcapture
+      return unless valid_configuration?
+
+      debug "Posting capture to #{configuration['endpoint']}"
+      RestClient.post(
+        api_url,
+        {
+          :files        => [File.new(self.runner.main_image)],
+          :message      => message,
+          :key          => configuration['optional_key']
+        },
+        {
+          "X-Protonet-Token" => configuration['api_token']
+        }
+      )
+
+    end
+
+    def api_url
+      configuration['api_endpoint']
+    end
+
+    def message
+      "commited some #{random_adjective} #{random_object} to #{self.runner.git_info.repo}@#{self.runner.sha}"
+    end
+
+    def random_object
+      objects = [
+        'screws', 'bolts', 'exceptions', 'errors', 'cookies'
+      ]
+
+      objects.sample
+    end
+
+    def random_adjective
+      adjectives = ["awesome", "great", "interesting", "cool", "EPIC", "gut", "good", "pansy",
+        "powerful", "boring", "quirky", "untested", "german", "iranian", "neutral", "crazy", "well tested",
+        "jimmy style", "nasty", "bibliographical (we received complaints about the original wording)", "bombdiggidy", "narly", "spiffy", "smashing", "xing style",
+        "leo apotheker style", "black", "white", "yellow", "shaggy", "tasty", "mind bending", "JAY-Z",
+        "Kanye (the best ever)", "* Toby Keith was here *", "splendid", "stupendulous",
+        "(freedom fries!)", "[vote RON PAUL]", "- these are not my glasses -", "typical pansy",
+        "- ze goggles zey do nothing! -", "almost working", "legen- wait for it -", "-dairy!",
+        " - Tavonius would be proud of this - ", "Meg FAILMAN!", "- very brofessional of you -",
+        "heartbleeding", "juciy", "supercalifragilisticexpialidocious", "failing", "loving"
+      ]
+      adjectives.sample
+    end
+
+    def configured?
+      !configuration['enabled'].nil? &&
+        configuration['api_token'] &&
+        configuration['api_endpoint']
+    end
+
+    def self.name
+      'lolprotonet'
+    end
+
+    def self.runner_order
+      :postcapture
+    end
+  end
+end

--- a/lib/lolcommits/plugins/lol_protonet.rb
+++ b/lib/lolcommits/plugins/lol_protonet.rb
@@ -37,7 +37,7 @@ module Lolcommits
     end
 
     def random_adjective
-      adjectives = %w{"awesome", "great", "interesting", "cool", "EPIC", "gut", "good", "pansy",
+      adjectives = ["awesome", "great", "interesting", "cool", "EPIC", "gut", "good", "pansy",
                       "powerful", "boring", "quirky", "untested", "german", "iranian", "neutral", "crazy", "well tested",
                       "jimmy style", "nasty", "bibliographical (we received complaints about the original wording)",
                       "bombdiggidy", "narly", "spiffy", "smashing", "xing style",
@@ -47,7 +47,7 @@ module Lolcommits
                       "- ze goggles zey do nothing! -", "almost working", "legen- wait for it -", "-dairy!",
                       " - Tavonius would be proud of this - ", "Meg FAILMAN!", "- very brofessional of you -",
                       "heartbleeding", "juciy", "supercalifragilisticexpialidocious", "failing", "loving"
-                   }
+                   ]
       adjectives.sample
     end
 

--- a/lib/lolcommits/plugins/lol_protonet.rb
+++ b/lib/lolcommits/plugins/lol_protonet.rb
@@ -27,7 +27,7 @@ module Lolcommits
     end
 
     def message
-      "commited some #{random_adjective} #{random_object} to #{self.runner.git_info.repo}@#{self.runner.sha}"
+      "commited some #{random_adjective} #{random_object} to #{self.runner.git_info.repo}@#{self.runner.sha} (#{self.runner.git_info.branch}) "
     end
 
     def random_object


### PR DESCRIPTION
This Plugin allows you to push the newly taken lolcommit to your protonet box.

You should follow the API Documentation found on your box under Help/"Protonet REST API" to get a api_token.

Have fun. 