### PR TITLE
Fix master rubocop problems

### DIFF
--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -60,7 +60,7 @@ end
 When /^I run `(.*?)` and wait for output$/ do |command|
   command = "cd #{current_dir} && #{command}"
   @stdin, @stdout, @stderr = Open3.popen3(command)
-  @fields = Hash.new
+  @fields = {}
 end
 
 Given /^a loldir named "(.*?)" with (\d+) lolimages$/ do |repo_name, num_images|

--- a/lib/lolcommits/plugin.rb
+++ b/lib/lolcommits/plugin.rb
@@ -46,7 +46,7 @@ module Lolcommits
     # ask for plugin options
     def configure_options!
       puts "Configuring plugin: #{self.class.name}\n"
-      options.reduce(Hash.new) do |acc, option|
+      options.reduce({}) do |acc, option|
         print "#{option}: "
         val = parse_user_input(STDIN.gets.strip)
         # check enabled option isn't a String

--- a/lib/lolcommits/plugins/lolsrv.rb
+++ b/lib/lolcommits/plugins/lolsrv.rb
@@ -33,7 +33,7 @@ module Lolcommits
 
     def existing_lols
       lols = JSON.parse(
-      RestClient.get(configuration['server'] + '/lols'))
+        RestClient.get(configuration['server'] + '/lols'))
       lols.map { |lol| lol['sha'] }
     rescue => e
       log_error(e, "ERROR: existing lols could not be retrieved #{e.class} - #{e.message}")


### PR DESCRIPTION
fixing failing RuboCop on Master. 

before:
```
~/Repositories/lolcommits (master)$ rake
Running RuboCop...
Inspecting 31 files
....C..............C...C.......

Offenses:

features/step_definitions/lolcommits_steps.rb:63:13: C: Use hash literal {} instead of Hash.new.
  @fields = Hash.new
            ^^^^^^^^
lib/lolcommits/plugin.rb:49:22: C: Use hash literal {} instead of Hash.new.
      options.reduce(Hash.new) do |acc, option|
                     ^^^^^^^^
lib/lolcommits/plugins/lolsrv.rb:36:7: C: Indent the first parameter one step more than the previous line.
      RestClient.get(configuration['server'] + '/lols'))
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

31 files inspected, 3 offenses detected
RuboCop failed!
```

after: 
```
~/Repositories/lolcommits (fix_master_rubocop_problems)$ rake
Running RuboCop...
Inspecting 31 files
...............................

31 files inspected, no offenses detected
… 
```