### PR TITLE
Exit with proper exit code.

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -28,6 +28,7 @@ def do_noargs
   puts 'Do what exactly?'
   puts 'Try: lolcommits --enable   (when in a git repository)'
   puts 'Or:  lolcommits --help'
+  exit 1
 end
 
 # Gets a configuration object.  If running in test mode will override the

--- a/features/bugs.feature
+++ b/features/bugs.feature
@@ -27,16 +27,18 @@ Feature: Bug regression testing
   # issue #80, https://github.com/mroth/lolcommits/issues/80
   #
   Scenario: don't warn about system_timer (on MRI 1.8.7)
-    When I successfully run `lolcommits`
+    When I run `lolcommits`
     Then the output should not contain "Faraday: you may want to install system_timer for reliable timeouts"
+    And the exit status should be 1
 
   #
   # issue #81, https://github.com/mroth/lolcommits/issues/81
   #
   Scenario: don't want to see initialized constant warning from Faraday on CLI (on MRI 1.8.7)
-    When I successfully run `lolcommits`
+    When I run `lolcommits`
     Then the output should not contain "warning: already initialized constant DEFAULT_BOUNDARY"
-  
+    And the exit status should be 1
+
   #
   # issue #87, https://github.com/mroth/lolcommits/issues/87
   #


### PR DESCRIPTION
I suppose this is somewhat subjective, however, I expected e.g.
```
$ lolcommits
$ lolcommits --option-that-doesnt-exist
```
to exit with a non-`0` code, sorta like how `git` does.