### PR TITLE
Clean up Aruba configuration and scenarios

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -113,6 +113,7 @@ def do_capture
 end
 
 def do_configure
+  $stdout.sync = true
   configuration.do_configure! Choice.choices[:plugin]
 end
 

--- a/features/bugs.feature
+++ b/features/bugs.feature
@@ -3,6 +3,9 @@ Feature: Bug regression testing
   I want to ensure fixed bugs stay fixed
   So that I don't have to fix them again!
 
+  Background:
+    Given a mocked home directory
+
   #
   # issue #58, https://github.com/mroth/lolcommits/issues/58
   #
@@ -36,7 +39,7 @@ Feature: Bug regression testing
   Scenario: don't want to see initialized constant warning from Faraday on CLI (on MRI 1.8.7)
     When I successfully run `lolcommits`
     Then the output should not contain "warning: already initialized constant DEFAULT_BOUNDARY"
-  
+
   #
   # issue #87, https://github.com/mroth/lolcommits/issues/87
   #

--- a/features/bugs.feature
+++ b/features/bugs.feature
@@ -10,7 +10,7 @@ Feature: Bug regression testing
   # issue #58, https://github.com/mroth/lolcommits/issues/58
   #
   Scenario: handle git repos with spaces in directory name
-    Given I am in a git repository named "test lolol" with lolcommits enabled
+    Given I am in a git repo named "test lolol" with lolcommits enabled
     And I successfully run `git commit --allow-empty -m 'can haz commit'`
     Then the output should contain "*** Preserving this moment in history."
     And a directory named "../.lolcommits/test-lolol" should exist
@@ -20,7 +20,7 @@ Feature: Bug regression testing
   #
   @fake-interactive-rebase @slow_process @unstable
   Scenario: Don't trigger capture during a git rebase
-    Given I am in a git repository named "yuh8history" with lolcommits enabled
+    Given I am in a git repo named "yuh8history" with lolcommits enabled
       And I do 6 git commits
     When I successfully run `git rebase -i HEAD~5`
     # Then there should be 4 commit entries in the git log
@@ -53,7 +53,7 @@ Feature: Bug regression testing
   # issue #50, https://github.com/mroth/lolcommits/issues/50
   #
   Scenario: catch upstream bug with ruby-git and color=always
-    Given I am in a git repository named "whatev" with lolcommits enabled
+    Given I am in a git repo named "whatev" with lolcommits enabled
     And I successfully run `git config color.ui always`
     When I run `lolcommits`
     Then the output should contain "Due to a bug in the ruby-git library, git config for color.ui cannot be set to 'always'."

--- a/features/bugs.feature
+++ b/features/bugs.feature
@@ -31,14 +31,20 @@ Feature: Bug regression testing
   #
   Scenario: don't warn about system_timer (on MRI 1.8.7)
     When I successfully run `lolcommits`
-    Then the output should not contain "Faraday: you may want to install system_timer for reliable timeouts"
+    Then the output should not contain:
+    """
+    Faraday: you may want to install system_timer for reliable timeouts
+    """
 
   #
   # issue #81, https://github.com/mroth/lolcommits/issues/81
   #
-  Scenario: don't want to see initialized constant warning from Faraday on CLI (on MRI 1.8.7)
+  Scenario: don't want initialized constant warning from Faraday (MRI 1.8.7)
     When I successfully run `lolcommits`
-    Then the output should not contain "warning: already initialized constant DEFAULT_BOUNDARY"
+    Then the output should not contain:
+    """
+    warning: already initialized constant DEFAULT_BOUNDARY
+    """
 
   #
   # issue #87, https://github.com/mroth/lolcommits/issues/87
@@ -46,7 +52,10 @@ Feature: Bug regression testing
   @fake-no-imagemagick
   Scenario: gracefully fail when imagemagick is not installed
     When I run `lolcommits`
-    Then the output should contain "ImageMagick does not appear to be properly installed"
+    Then the output should contain:
+      """
+      ImageMagick does not appear to be properly installed
+      """
     And the exit status should be 1
 
   #
@@ -56,6 +65,9 @@ Feature: Bug regression testing
     Given I am in a git repo named "whatev" with lolcommits enabled
     And I successfully run `git config color.ui always`
     When I run `lolcommits`
-    Then the output should contain "Due to a bug in the ruby-git library, git config for color.ui cannot be set to 'always'."
+    Then the output should contain:
+      """
+      Due to a bug in the ruby-git library, git config for color.ui cannot be set to 'always'.
+      """
     And the output should contain "Try setting it to 'auto' instead!"
     And the exit status should be 1

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -20,8 +20,8 @@ Feature: Basic UI functionality
     When I get help for "lolcommits"
     Then the output should not match /\-a\, \-\-animate\=SECONDS/
 
-  Scenario: Enable in a naked git repository
-    Given a git repository named "loltest" with no "post-commit" hook
+  Scenario: Enable in a naked git repo
+    Given a git repo named "loltest" with no "post-commit" hook
     When I cd to "loltest"
     And I successfully run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
@@ -30,9 +30,9 @@ Feature: Basic UI functionality
       And the file ".git/hooks/post-commit" should contain "lolcommits --capture"
       And the exit status should be 0
 
-  Scenario: Enable in a git repository that already has a post-commit hook
-    Given a git repository named "loltest" with a "post-commit" hook
-      And the "loltest" repository "post-commit" hook has content "#!/bin/sh\n\n/my/own/script"
+  Scenario: Enable in a git repo that already has a post-commit hook
+    Given a git repo named "loltest" with a "post-commit" hook
+      And the "loltest" repo "post-commit" hook has content "#!/bin/sh\n\n/my/own/script"
     When I cd to "loltest"
     And I successfully run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
@@ -43,17 +43,17 @@ Feature: Basic UI functionality
       And the file ".git/hooks/post-commit" should contain "lolcommits --capture"
       And the exit status should be 0
 
-  Scenario: Enable in a git repository that already has post-commit hook with a bad shebang
-    Given a git repository named "loltest" with a "post-commit" hook
-      And the "loltest" repository "post-commit" hook has content "#!/bin/ruby"
+  Scenario: Enable in a git repo that already has post-commit hook with a bad shebang
+    Given a git repo named "loltest" with a "post-commit" hook
+      And the "loltest" repo "post-commit" hook has content "#!/bin/ruby"
     When I cd to "loltest"
     And I run `lolcommits --enable`
     Then the output should contain "doesn't start with a good shebang"
       And the file ".git/hooks/post-commit" should not contain "lolcommits --capture"
       And the exit status should be 1
 
-  Scenario: Enable in a git repository passing capture arguments
-    Given a git repository named "loltest" with no "post-commit" hook
+  Scenario: Enable in a git repo passing capture arguments
+    Given a git repo named "loltest" with no "post-commit" hook
     When I cd to "loltest"
     And I successfully run `lolcommits --enable -w 5 --fork`
     Then the output should contain "installed lolcommit hook to:"
@@ -62,8 +62,8 @@ Feature: Basic UI functionality
       And the file ".git/hooks/post-commit" should contain "lolcommits --capture -w 5 --fork"
       And the exit status should be 0
 
-  Scenario: Disable in a enabled git repository
-    Given I am in a git repository named "lolenabled" with lolcommits enabled
+  Scenario: Disable in a enabled git repo
+    Given I am in a git repo named "lolenabled" with lolcommits enabled
     When I successfully run `lolcommits --disable`
     Then the output should contain "uninstalled"
       And a file named ".git/hooks/post-commit" should exist
@@ -77,7 +77,7 @@ Feature: Basic UI functionality
       And the exit status should be 1
 
   Scenario: Capture doesnt break in forked mode
-    Given I am in a git repository named "testforkcapture"
+    Given I am in a git repo named "testforkcapture"
     And I do a git commit
     When I successfully run `lolcommits --capture --fork`
     Then there should be exactly 1 pid in "../.lolcommits/testforkcapture"
@@ -87,7 +87,7 @@ Feature: Basic UI functionality
       And there should be exactly 1 jpg in "../.lolcommits/testforkcapture"
 
   Scenario: Commiting in an enabled repo triggers successful capture
-    Given I am in a git repository named "testcapture" with lolcommits enabled
+    Given I am in a git repo named "testcapture" with lolcommits enabled
     When I do a git commit
     Then the output should contain "*** Preserving this moment in history."
       And a directory named "../.lolcommits/testcapture" should exist
@@ -95,7 +95,7 @@ Feature: Basic UI functionality
       And there should be exactly 1 jpg in "../.lolcommits/testcapture"
 
   Scenario: Commiting in an enabled repo subdirectory triggers successful capture of parent repo
-    Given I am in a git repository named "testcapture" with lolcommits enabled
+    Given I am in a git repo named "testcapture" with lolcommits enabled
       And a directory named "subdir"
       And an empty file named "subdir/FOOBAR"
     When I cd to "subdir/"
@@ -106,14 +106,14 @@ Feature: Basic UI functionality
       And there should be exactly 1 jpg in "../../.lolcommits/testcapture"
 
   Scenario: Stealth mode does not alert the user
-    Given I am in a git repository named "teststealth"
+    Given I am in a git repo named "teststealth"
     And I do a git commit
     When I run `lolcommits --stealth --capture`
     Then the output should not contain "*** Preserving this moment in history."
       And there should be exactly 1 jpg in "../.lolcommits/teststealth"
 
   Scenario: Commiting in stealth mode triggers successful capture without alerting the committer
-    Given I am in a git repository named "teststealth" with lolcommits enabled
+    Given I am in a git repo named "teststealth" with lolcommits enabled
         And I have environment variable LOLCOMMITS_STEALTH set to 1
     When I do a git commit
     Then the output should not contain "*** Preserving this moment in history."
@@ -128,7 +128,7 @@ Feature: Basic UI functionality
   # of elegance, but its passing so might as well leave in for now.
   #
   Scenario: Configuring plugin (with native aruba steps)
-    Given a git repository named "config-test"
+    Given a git repo named "config-test"
     When I cd to "config-test"
     And I run `lolcommits --config` interactively
     When I type "loltext"
@@ -143,7 +143,7 @@ Feature: Basic UI functionality
     And the output should contain "enabled: true"
 
   Scenario: Configuring Plugin
-    Given a git repository named "config-test"
+    Given a git repo named "config-test"
     When I cd to "config-test"
     And I run `lolcommits --config` and wait for output
     When I enter "loltext" for "Name of plugin to configure"
@@ -155,7 +155,7 @@ Feature: Basic UI functionality
     And the output should contain "enabled: true"
 
   Scenario: Configuring Plugin In Test Mode
-    Given a git repository named "testmode-config-test"
+    Given a git repo named "testmode-config-test"
     When I cd to "testmode-config-test"
     And I run `lolcommits --config --test` and wait for output
     And I enter "loltext" for "Name of plugin to configure"
@@ -166,7 +166,7 @@ Feature: Basic UI functionality
     Then the output should contain "loltext:"
     And the output should contain "enabled: true"
 
-  Scenario: test capture should work regardless of whether in a git repository
+  Scenario: test capture should work regardless of whether in a git repo
     Given I am in a directory named "nothingtoseehere"
     When I run `lolcommits --test --capture`
     Then the output should contain "*** Capturing in test mode."
@@ -174,20 +174,20 @@ Feature: Basic UI functionality
       And the exit status should be 0
 
   Scenario: test capture should store in its own test directory
-    Given I am in a git repository named "randomgitrepo" with lolcommits enabled
+    Given I am in a git repo named "randomgitrepo" with lolcommits enabled
     When I successfully run `lolcommits --test --capture`
     Then a directory named "../.lolcommits/test" should exist
     And a directory named "../.lolcommits/randomgitrepo" should not exist
 
   Scenario: last command should work properly when in a lolrepo
-    Given a git repository named "randomgitrepo"
+    Given a git repo named "randomgitrepo"
       And a loldir named "randomgitrepo" with 2 lolimages
       And I cd to "randomgitrepo"
     When I run `lolcommits --last`
     Then the exit status should be 0
 
   Scenario: last command should work properly when in a lolrepo subdirectory
-    Given I am in a git repository named "randomgitrepo"
+    Given I am in a git repo named "randomgitrepo"
       And a loldir named "randomgitrepo" with 2 lolimages
       And a directory named "randomdir"
       And I cd to "randomdir"
@@ -203,7 +203,7 @@ Feature: Basic UI functionality
     And the exit status should be 1
 
   Scenario: last command should fail gracefully if zero lolimages in lolrepo
-    Given a git repository named "randomgitrepo"
+    Given a git repo named "randomgitrepo"
     And a loldir named "randomgitrepo" with 0 lolimages
     And I cd to "randomgitrepo"
     When I run `lolcommits --last`
@@ -211,14 +211,14 @@ Feature: Basic UI functionality
     Then the exit status should be 1
 
   Scenario: browse command should work properly when in a lolrepo
-    Given a git repository named "randomgitrepo"
+    Given a git repo named "randomgitrepo"
       And a loldir named "randomgitrepo" with 2 lolimages
       And I cd to "randomgitrepo"
     When I run `lolcommits --browse`
     Then the exit status should be 0
 
   Scenario: browse command should work properly when in a lolrepo subdirectory
-    Given I am in a git repository named "randomgitrepo"
+    Given I am in a git repo named "randomgitrepo"
       And a loldir named "randomgitrepo" with 2 lolimages
       And a directory named "randomdir"
       And I cd to "randomdir"
@@ -234,13 +234,13 @@ Feature: Basic UI functionality
       And the exit status should be 1
 
   Scenario: handle commit messages with quotation marks
-    Given I am in a git repository named "shellz" with lolcommits enabled
+    Given I am in a git repo named "shellz" with lolcommits enabled
     When I successfully run `git commit --allow-empty -m 'i hate \"air quotes\" dont you'`
     Then the exit status should be 0
       And there should be exactly 1 jpg in "../.lolcommits/shellz"
 
   Scenario: generate gif should store in its own archive directory
-    Given I am in a git repository named "randomgitrepo" with lolcommits enabled
+    Given I am in a git repo named "randomgitrepo" with lolcommits enabled
       And a loldir named "randomgitrepo" with 2 lolimages
     When I successfully run `lolcommits -g`
     Then the output should contain "Generating animated gif."
@@ -248,14 +248,14 @@ Feature: Basic UI functionality
     And a file named "../.lolcommits/randomgitrepo/archive/archive.gif" should exist
 
   Scenario: generate gif with argument 'today'
-    Given I am in a git repository named "randomgitrepo" with lolcommits enabled
+    Given I am in a git repo named "randomgitrepo" with lolcommits enabled
       And a loldir named "randomgitrepo" with 2 lolimages
     When I successfully run `lolcommits -g today`
       And there should be exactly 1 gif in "../.lolcommits/randomgitrepo/archive"
 
   @mac-only
   Scenario: should generate an animated gif on the Mac platform
-    Given I am in a git repository named "testanimatedcapture"
+    Given I am in a git repo named "testanimatedcapture"
       And I do a git commit
       And I am using a "Mac" platform
     When I run `lolcommits --capture --animate=1`

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -12,8 +12,8 @@ Feature: Basic UI functionality
     Given I am using a "Mac" platform
     When I get help for "lolcommits"
     Then the following options should be documented:
-      |--animate|which is optional|
-      |-a       |which is optional|
+      | --animate | which is optional |
+      | -a        | which is optional |
 
   Scenario: Help should not show the animate option on a Windows plaftorm
     Given I am using a "Windows" platform
@@ -123,48 +123,30 @@ Feature: Basic UI functionality
     When I successfully run `lolcommits --plugins`
     Then the output should contain a list of plugins
 
-  #
-  # a stab at recreating ken's scenarios with native aruba steps, not quite there yet in terms
-  # of elegance, but its passing so might as well leave in for now.
-  #
-  Scenario: Configuring plugin (with native aruba steps)
-    Given a git repo named "config-test"
-    When I cd to "config-test"
-    And I run `lolcommits --config` interactively
-    When I type "loltext"
-    When I type "true"
-    Then the output should contain a list of plugins
-    And the output should contain "Name of plugin to configure:"
-    Then the output should contain "enabled:"
+  Scenario: Configuring plugin
+    Given I am in a git repo named "config-test"
+    When I run `lolcommits --config` interactively
+      And I wait for output to contain "Name of plugin to configure:"
+      Then I type "loltext"
+      And I wait for output to contain "enabled:"
+      Then I type "true"
     Then the output should contain "Successfully configured plugin: loltext"
+    And the output should contain a list of plugins
     And a file named "../.lolcommits/config-test/config.yml" should exist
     When I successfully run `lolcommits --show-config`
-    Then the output should contain "loltext:"
-    And the output should contain "enabled: true"
+    Then the output should match /loltext:\s+enabled: true/
 
-  Scenario: Configuring Plugin
-    Given a git repo named "config-test"
-    When I cd to "config-test"
-    And I run `lolcommits --config` and wait for output
-    When I enter "loltext" for "Name of plugin to configure"
-    And I enter "true" for "enabled"
-    Then I should be presented "Successfully configured plugin: loltext"
-    And a file named "../.lolcommits/config-test/config.yml" should exist
-    When I successfully run `lolcommits --show-config`
-    Then the output should contain "loltext:"
-    And the output should contain "enabled: true"
-
-  Scenario: Configuring Plugin In Test Mode
-    Given a git repo named "testmode-config-test"
-    When I cd to "testmode-config-test"
-    And I run `lolcommits --config --test` and wait for output
-    And I enter "loltext" for "Name of plugin to configure"
-    And I enter "true" for "enabled"
-    Then I should be presented "Successfully configured plugin: loltext"
+  Scenario: Configuring plugin in test mode
+    Given I am in a git repo named "testmode-config-test"
+    When I run `lolcommits --config --test` interactively
+      And I wait for output to contain "Name of plugin to configure:"
+      Then I type "loltext"
+      And I wait for output to contain "enabled:"
+      Then I type "true"
+    Then the output should contain "Successfully configured plugin: loltext"
     And a file named "../.lolcommits/test/config.yml" should exist
     When I successfully run `lolcommits --test --show-config`
-    Then the output should contain "loltext:"
-    And the output should contain "enabled: true"
+    Then the output should match /loltext:\s+enabled: true/
 
   Scenario: test capture should work regardless of whether in a git repo
     Given I am in a directory named "nothingtoseehere"

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -104,11 +104,11 @@ Feature: Basic UI functionality
     And there should be exactly 1 jpg in "~/.lolcommits/teststealth"
 
   Scenario: Commiting in stealth mode captures without alerting the committer
-    Given I am in a git repo named "teststealth" with lolcommits enabled
+    Given I am in a git repo with lolcommits enabled
     And I have environment variable LOLCOMMITS_STEALTH set to 1
     When I do a git commit
     Then the output should not contain "*** Preserving this moment in history."
-    And there should be exactly 1 jpg in "~/.lolcommits/teststealth"
+    And there should be exactly 1 jpg in its loldir
 
   Scenario: Show plugins
     When I successfully run `lolcommits --plugins`
@@ -127,7 +127,7 @@ Feature: Basic UI functionality
     When I successfully run `lolcommits --show-config`
     Then the output should match /loltext:\s+enabled: true/
 
-  Scenario: Configuring plugin in test mode
+  Scenario: Configuring plugin in test mode affects test loldir not repo loldir
     Given I am in a git repo named "testmode-config-test"
     When I run `lolcommits --config --test` interactively
       And I wait for output to contain "Name of plugin to configure:"
@@ -153,15 +153,14 @@ Feature: Basic UI functionality
     And a directory named "~/.lolcommits/randomgitrepo" should not exist
 
   Scenario: last command should work properly when in a lolrepo
-    Given a git repo named "randomgitrepo"
-      And a loldir named "randomgitrepo" with 2 lolimages
-      And I cd to "randomgitrepo"
+    Given I am in a git repo
+    And its loldir has 2 lolimages
     When I run `lolcommits --last`
     Then the exit status should be 0
 
   Scenario: last command should work properly when in a lolrepo subdirectory
-    Given I am in a git repo named "randomgitrepo"
-      And a loldir named "randomgitrepo" with 2 lolimages
+    Given I am in a git repo
+      And its loldir has 2 lolimages
       And a directory named "randomdir"
       And I cd to "randomdir"
     When I run `lolcommits --last`
@@ -182,9 +181,8 @@ Feature: Basic UI functionality
     And the exit status should be 1
 
   Scenario: last command should fail gracefully if zero lolimages in lolrepo
-    Given a git repo named "randomgitrepo"
-    And a loldir named "randomgitrepo" with 0 lolimages
-    And I cd to "randomgitrepo"
+    Given I am in a git repo
+    And its loldir has 0 lolimages
     When I run `lolcommits --last`
     Then the output should contain:
       """
@@ -193,17 +191,16 @@ Feature: Basic UI functionality
     Then the exit status should be 1
 
   Scenario: browse command should work properly when in a lolrepo
-    Given a git repo named "randomgitrepo"
-      And a loldir named "randomgitrepo" with 2 lolimages
-      And I cd to "randomgitrepo"
+    Given I am in a git repo
+    And its loldir has 2 lolimages
     When I run `lolcommits --browse`
     Then the exit status should be 0
 
   Scenario: browse command should work properly when in a lolrepo subdirectory
-    Given I am in a git repo named "randomgitrepo"
-      And a loldir named "randomgitrepo" with 2 lolimages
-      And a directory named "randomdir"
-      And I cd to "randomdir"
+    Given I am in a git repo
+      And its loldir has 2 lolimages
+      And a directory named "subdir"
+      And I cd to "subdir"
     When I run `lolcommits --browse`
     Then the output should not contain:
       """
@@ -221,14 +218,12 @@ Feature: Basic UI functionality
       """
     And the exit status should be 1
 
-  @wip
   Scenario: handle commit messages with quotation marks
-    Given I am in a git repo named "shellz" with lolcommits enabled
+    Given I am in a git repo with lolcommits enabled
     When I successfully run `git commit --allow-empty -m 'no "air quotes" bae'`
     Then the exit status should be 0
-    And there should be exactly 1 jpg in "~/.lolcommits/shellz"
+    And there should be exactly 1 jpg in its loldir
 
-  @wip
   Scenario: generate gif should store in its own archive directory
     Given I am in a git repo named "giffy" with lolcommits enabled
       And a loldir named "giffy" with 2 lolimages

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -25,9 +25,15 @@ Feature: Basic UI functionality
     When I cd to "loltest"
     And I successfully run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
-      And the output should contain "(to remove later, you can use: lolcommits --disable)"
+      And the output should contain:
+        """
+        (to remove later, you can use: lolcommits --disable)
+        """
       And a file named ".git/hooks/post-commit" should exist
-      And the file ".git/hooks/post-commit" should contain "lolcommits --capture"
+      And the file ".git/hooks/post-commit" should contain:
+        """
+        lolcommits --capture
+        """
       And the exit status should be 0
 
   Scenario: Enable in a git repo that already has a post-commit hook
@@ -36,20 +42,26 @@ Feature: Basic UI functionality
     When I cd to "loltest"
     And I successfully run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
-      And the output should contain "(to remove later, you can use: lolcommits --disable)"
+      And the output should contain:
+        """
+        (to remove later, you can use: lolcommits --disable)
+        """
       And a file named ".git/hooks/post-commit" should exist
       And the file ".git/hooks/post-commit" should contain "#!/bin/sh"
       And the file ".git/hooks/post-commit" should contain "/my/own/script"
       And the file ".git/hooks/post-commit" should contain "lolcommits --capture"
       And the exit status should be 0
 
-  Scenario: Enable in a git repo that already has post-commit hook with a bad shebang
+  Scenario: Enable in a git repo that has post-commit hook with a bad shebang
     Given a git repo named "loltest" with a "post-commit" hook
       And the "loltest" repo "post-commit" hook has content "#!/bin/ruby"
     When I cd to "loltest"
     And I run `lolcommits --enable`
     Then the output should contain "doesn't start with a good shebang"
-      And the file ".git/hooks/post-commit" should not contain "lolcommits --capture"
+      And the file ".git/hooks/post-commit" should not contain:
+        """
+        lolcommits --capture
+        """
       And the exit status should be 1
 
   Scenario: Enable in a git repo passing capture arguments
@@ -57,9 +69,15 @@ Feature: Basic UI functionality
     When I cd to "loltest"
     And I successfully run `lolcommits --enable -w 5 --fork`
     Then the output should contain "installed lolcommit hook to:"
-      And the output should contain "(to remove later, you can use: lolcommits --disable)"
+      And the output should contain:
+        """
+        (to remove later, you can use: lolcommits --disable)
+        """
       And a file named ".git/hooks/post-commit" should exist
-      And the file ".git/hooks/post-commit" should contain "lolcommits --capture -w 5 --fork"
+      And the file ".git/hooks/post-commit" should contain:
+        """
+        lolcommits --capture -w 5 --fork
+        """
       And the exit status should be 0
 
   Scenario: Disable in a enabled git repo
@@ -67,34 +85,40 @@ Feature: Basic UI functionality
     When I successfully run `lolcommits --disable`
     Then the output should contain "uninstalled"
       And a file named ".git/hooks/post-commit" should exist
-      And the file ".git/hooks/post-commit" should not contain "lolcommits --capture"
+      And the file ".git/hooks/post-commit" should not contain:
+        """
+        lolcommits --capture
+        """
       And the exit status should be 0
 
   Scenario: Trying to enable while not in a git repo fails
     Given I am in a directory named "svnrulez"
     When I run `lolcommits --enable`
-    Then the output should contain "You don't appear to be in the base directory of a git project."
-      And the exit status should be 1
+    Then the output should contain:
+      """
+      You don't appear to be in the base directory of a git project.
+      """
+    And the exit status should be 1
 
   Scenario: Capture doesnt break in forked mode
-    Given I am in a git repo named "testforkcapture"
+    Given I am in a git repo named "forked"
     And I do a git commit
     When I successfully run `lolcommits --capture --fork`
-    Then there should be exactly 1 pid in "../.lolcommits/testforkcapture"
-    When I wait for the child process to exit in "testforkcapture"
-    Then a directory named "../.lolcommits/testforkcapture" should exist
-      And a file named "../.lolcommits/testforkcapture/tmp_snapshot.jpg" should not exist
-      And there should be exactly 1 jpg in "../.lolcommits/testforkcapture"
+    Then there should be exactly 1 pid in "../.lolcommits/forked"
+    When I wait for the child process to exit in "forked"
+    Then a directory named "../.lolcommits/forked" should exist
+      And a file named "../.lolcommits/forked/tmp_snapshot.jpg" should not exist
+      And there should be exactly 1 jpg in "../.lolcommits/forked"
 
   Scenario: Commiting in an enabled repo triggers successful capture
-    Given I am in a git repo named "testcapture" with lolcommits enabled
+    Given I am in a git repo named "myrepo" with lolcommits enabled
     When I do a git commit
     Then the output should contain "*** Preserving this moment in history."
-      And a directory named "../.lolcommits/testcapture" should exist
-      And a file named "../.lolcommits/testcapture/tmp_snapshot.jpg" should not exist
-      And there should be exactly 1 jpg in "../.lolcommits/testcapture"
+      And a directory named "../.lolcommits/myrepo" should exist
+      And a file named "../.lolcommits/myrepo/tmp_snapshot.jpg" should not exist
+      And there should be exactly 1 jpg in "../.lolcommits/myrepo"
 
-  Scenario: Commiting in an enabled repo subdirectory triggers successful capture of parent repo
+  Scenario: Commiting in enabled repo subdirectory triggers successful capture
     Given I am in a git repo named "testcapture" with lolcommits enabled
       And a directory named "subdir"
       And an empty file named "subdir/FOOBAR"
@@ -110,14 +134,14 @@ Feature: Basic UI functionality
     And I do a git commit
     When I run `lolcommits --stealth --capture`
     Then the output should not contain "*** Preserving this moment in history."
-      And there should be exactly 1 jpg in "../.lolcommits/teststealth"
+    And there should be exactly 1 jpg in "../.lolcommits/teststealth"
 
-  Scenario: Commiting in stealth mode triggers successful capture without alerting the committer
+  Scenario: Commiting in stealth mode captures without alerting the committer
     Given I am in a git repo named "teststealth" with lolcommits enabled
-        And I have environment variable LOLCOMMITS_STEALTH set to 1
+    And I have environment variable LOLCOMMITS_STEALTH set to 1
     When I do a git commit
     Then the output should not contain "*** Preserving this moment in history."
-      And there should be exactly 1 jpg in "../.lolcommits/teststealth"
+    And there should be exactly 1 jpg in "../.lolcommits/teststealth"
 
   Scenario: Show plugins
     When I successfully run `lolcommits --plugins`
@@ -174,14 +198,20 @@ Feature: Basic UI functionality
       And a directory named "randomdir"
       And I cd to "randomdir"
     When I run `lolcommits --last`
-    Then the output should not contain "Can't do that since we're not in a valid git repository!"
-     And the exit status should be 0
+    Then the output should not contain:
+      """
+      Can't do that since we're not in a valid git repository!
+      """
+    And the exit status should be 0
 
   @in-tempdir
   Scenario: last command should fail gracefully if not in a lolrepo
     Given I am in a directory named "gitsuxcvs4eva"
     When I run `lolcommits --last`
-    Then the output should contain "Can't do that since we're not in a valid git repository!"
+    Then the output should contain:
+      """
+      Can't do that since we're not in a valid git repository!
+      """
     And the exit status should be 1
 
   Scenario: last command should fail gracefully if zero lolimages in lolrepo
@@ -189,7 +219,10 @@ Feature: Basic UI functionality
     And a loldir named "randomgitrepo" with 0 lolimages
     And I cd to "randomgitrepo"
     When I run `lolcommits --last`
-    Then the output should contain "No lolcommits have been captured for this repository yet."
+    Then the output should contain:
+      """
+      No lolcommits have been captured for this repository yet.
+      """
     Then the exit status should be 1
 
   Scenario: browse command should work properly when in a lolrepo
@@ -205,51 +238,60 @@ Feature: Basic UI functionality
       And a directory named "randomdir"
       And I cd to "randomdir"
     When I run `lolcommits --browse`
-    Then the output should not contain "Can't do that since we're not in a valid git repository!"
-     And the exit status should be 0
+    Then the output should not contain:
+      """
+      Can't do that since we're not in a valid git repository!
+      """
+    And the exit status should be 0
 
   @in-tempdir
   Scenario: browse command should fail gracefully when not in a lolrepo
     Given I am in a directory named "gitsuxcvs4eva"
     When I run `lolcommits --browse`
-    Then the output should contain "Can't do that since we're not in a valid git repository!"
-      And the exit status should be 1
+    Then the output should contain:
+      """
+      Can't do that since we're not in a valid git repository!
+      """
+    And the exit status should be 1
 
   Scenario: handle commit messages with quotation marks
     Given I am in a git repo named "shellz" with lolcommits enabled
-    When I successfully run `git commit --allow-empty -m 'i hate \"air quotes\" dont you'`
+    When I successfully run `git commit --allow-empty -m 'no "air quotes" bae'`
     Then the exit status should be 0
-      And there should be exactly 1 jpg in "../.lolcommits/shellz"
+    And there should be exactly 1 jpg in "../.lolcommits/shellz"
 
   Scenario: generate gif should store in its own archive directory
-    Given I am in a git repo named "randomgitrepo" with lolcommits enabled
-      And a loldir named "randomgitrepo" with 2 lolimages
+    Given I am in a git repo named "giffy" with lolcommits enabled
+      And a loldir named "giffy" with 2 lolimages
     When I successfully run `lolcommits -g`
     Then the output should contain "Generating animated gif."
-    And a directory named "../.lolcommits/randomgitrepo/archive" should exist
-    And a file named "../.lolcommits/randomgitrepo/archive/archive.gif" should exist
+      And a directory named "../.lolcommits/giffy/archive" should exist
+      And a file named "../.lolcommits/giffy/archive/archive.gif" should exist
 
   Scenario: generate gif with argument 'today'
-    Given I am in a git repo named "randomgitrepo" with lolcommits enabled
-      And a loldir named "randomgitrepo" with 2 lolimages
+    Given I am in a git repo named "sunday" with lolcommits enabled
+      And a loldir named "sunday" with 2 lolimages
     When I successfully run `lolcommits -g today`
-      And there should be exactly 1 gif in "../.lolcommits/randomgitrepo/archive"
+    Then there should be exactly 1 gif in "../.lolcommits/sunday/archive"
 
   @mac-only
   Scenario: should generate an animated gif on the Mac platform
-    Given I am in a git repo named "testanimatedcapture"
+    Given I am in a git repo named "animate"
       And I do a git commit
       And I am using a "Mac" platform
     When I run `lolcommits --capture --animate=1`
     Then the output should contain "*** Preserving this moment in history."
-      And a directory named "../.lolcommits/testanimatedcapture" should exist
-      And a file named "../.lolcommits/testanimatedcapture/tmp_video.mov" should not exist
-      And a directory named "../.lolcommits/testanimatedcapture/tmp_frames" should not exist
-      And there should be exactly 1 gif in "../.lolcommits/testanimatedcapture"
+      And a directory named "../.lolcommits/animate" should exist
+      And a file named "../.lolcommits/animate/tmp_video.mov" should not exist
+      And a directory named "../.lolcommits/animate/tmp_frames" should not exist
+      And there should be exactly 1 gif in "../.lolcommits/animate"
 
   @fake-no-ffmpeg
-  Scenario: gracefully fail when ffmpeg is not installed and animate option is used
+  Scenario: gracefully fail when ffmpeg not installed and --animate is used
     Given I am using a "Mac" platform
     When I run `lolcommits --animate=3`
-    Then the output should contain "ffmpeg does not appear to be properly installed"
+    Then the output should contain:
+      """
+      ffmpeg does not appear to be properly installed
+      """
     And the exit status should be 1

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -1,5 +1,8 @@
 Feature: Basic UI functionality
 
+  Background:
+    Given a mocked home directory
+
   Scenario: App just runs
     When I get help for "lolcommits"
     Then the exit status should be 0

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -71,19 +71,19 @@ Feature: Basic UI functionality
     Given I am in a git repo named "forked"
     And I do a git commit
     When I successfully run `lolcommits --capture --fork`
-    Then there should be exactly 1 pid in "../.lolcommits/forked"
+    Then there should be exactly 1 pid in "~/.lolcommits/forked"
     When I wait for the child process to exit in "forked"
-    Then a directory named "../.lolcommits/forked" should exist
-      And a file named "../.lolcommits/forked/tmp_snapshot.jpg" should not exist
-      And there should be exactly 1 jpg in "../.lolcommits/forked"
+    Then a directory named "~/.lolcommits/forked" should exist
+      And a file named "~/.lolcommits/forked/tmp_snapshot.jpg" should not exist
+      And there should be exactly 1 jpg in "~/.lolcommits/forked"
 
   Scenario: Commiting in an enabled repo triggers successful capture
     Given I am in a git repo named "myrepo" with lolcommits enabled
     When I do a git commit
     Then the output should contain "*** Preserving this moment in history."
-      And a directory named "../.lolcommits/myrepo" should exist
-      And a file named "../.lolcommits/myrepo/tmp_snapshot.jpg" should not exist
-      And there should be exactly 1 jpg in "../.lolcommits/myrepo"
+      And a directory named "~/.lolcommits/myrepo" should exist
+      And a file named "~/.lolcommits/myrepo/tmp_snapshot.jpg" should not exist
+      And there should be exactly 1 jpg in "~/.lolcommits/myrepo"
 
   Scenario: Commiting in enabled repo subdirectory triggers successful capture
     Given I am in a git repo named "testcapture" with lolcommits enabled
@@ -92,23 +92,23 @@ Feature: Basic UI functionality
     When I cd to "subdir/"
       And I do a git commit
     Then the output should contain "*** Preserving this moment in history."
-      And a directory named "../../.lolcommits/testcapture" should exist
-      And a directory named "../../.lolcommits/subdir" should not exist
-      And there should be exactly 1 jpg in "../../.lolcommits/testcapture"
+      And a directory named "~/.lolcommits/testcapture" should exist
+      And a directory named "~/.lolcommits/subdir" should not exist
+      And there should be exactly 1 jpg in "~/.lolcommits/testcapture"
 
   Scenario: Stealth mode does not alert the user
     Given I am in a git repo named "teststealth"
     And I do a git commit
     When I run `lolcommits --stealth --capture`
     Then the output should not contain "*** Preserving this moment in history."
-    And there should be exactly 1 jpg in "../.lolcommits/teststealth"
+    And there should be exactly 1 jpg in "~/.lolcommits/teststealth"
 
   Scenario: Commiting in stealth mode captures without alerting the committer
     Given I am in a git repo named "teststealth" with lolcommits enabled
     And I have environment variable LOLCOMMITS_STEALTH set to 1
     When I do a git commit
     Then the output should not contain "*** Preserving this moment in history."
-    And there should be exactly 1 jpg in "../.lolcommits/teststealth"
+    And there should be exactly 1 jpg in "~/.lolcommits/teststealth"
 
   Scenario: Show plugins
     When I successfully run `lolcommits --plugins`
@@ -123,7 +123,7 @@ Feature: Basic UI functionality
       Then I type "true"
     Then the output should contain "Successfully configured plugin: loltext"
     And the output should contain a list of plugins
-    And a file named "../.lolcommits/config-test/config.yml" should exist
+    And a file named "~/.lolcommits/config-test/config.yml" should exist
     When I successfully run `lolcommits --show-config`
     Then the output should match /loltext:\s+enabled: true/
 
@@ -135,7 +135,7 @@ Feature: Basic UI functionality
       And I wait for output to contain "enabled:"
       Then I type "true"
     Then the output should contain "Successfully configured plugin: loltext"
-    And a file named "../.lolcommits/test/config.yml" should exist
+    And a file named "~/.lolcommits/test/config.yml" should exist
     When I successfully run `lolcommits --test --show-config`
     Then the output should match /loltext:\s+enabled: true/
 
@@ -149,8 +149,8 @@ Feature: Basic UI functionality
   Scenario: test capture should store in its own test directory
     Given I am in a git repo named "randomgitrepo" with lolcommits enabled
     When I successfully run `lolcommits --test --capture`
-    Then a directory named "../.lolcommits/test" should exist
-    And a directory named "../.lolcommits/randomgitrepo" should not exist
+    Then a directory named "~/.lolcommits/test" should exist
+    And a directory named "~/.lolcommits/randomgitrepo" should not exist
 
   Scenario: last command should work properly when in a lolrepo
     Given a git repo named "randomgitrepo"
@@ -221,25 +221,27 @@ Feature: Basic UI functionality
       """
     And the exit status should be 1
 
+  @wip
   Scenario: handle commit messages with quotation marks
     Given I am in a git repo named "shellz" with lolcommits enabled
     When I successfully run `git commit --allow-empty -m 'no "air quotes" bae'`
     Then the exit status should be 0
-    And there should be exactly 1 jpg in "../.lolcommits/shellz"
+    And there should be exactly 1 jpg in "~/.lolcommits/shellz"
 
+  @wip
   Scenario: generate gif should store in its own archive directory
     Given I am in a git repo named "giffy" with lolcommits enabled
       And a loldir named "giffy" with 2 lolimages
     When I successfully run `lolcommits -g`
     Then the output should contain "Generating animated gif."
-      And a directory named "../.lolcommits/giffy/archive" should exist
-      And a file named "../.lolcommits/giffy/archive/archive.gif" should exist
+      And a directory named "~/.lolcommits/giffy/archive" should exist
+      And a file named "~/.lolcommits/giffy/archive/archive.gif" should exist
 
   Scenario: generate gif with argument 'today'
     Given I am in a git repo named "sunday" with lolcommits enabled
       And a loldir named "sunday" with 2 lolimages
     When I successfully run `lolcommits -g today`
-    Then there should be exactly 1 gif in "../.lolcommits/sunday/archive"
+    Then there should be exactly 1 gif in "~/.lolcommits/sunday/archive"
 
   @mac-only
   Scenario: should generate an animated gif on the Mac platform
@@ -248,10 +250,10 @@ Feature: Basic UI functionality
       And I am using a "Mac" platform
     When I run `lolcommits --capture --animate=1`
     Then the output should contain "*** Preserving this moment in history."
-      And a directory named "../.lolcommits/animate" should exist
-      And a file named "../.lolcommits/animate/tmp_video.mov" should not exist
-      And a directory named "../.lolcommits/animate/tmp_frames" should not exist
-      And there should be exactly 1 gif in "../.lolcommits/animate"
+      And a directory named "~/.lolcommits/animate" should exist
+      And a file named "~/.lolcommits/animate/tmp_video.mov" should not exist
+      And a directory named "~/.lolcommits/animate/tmp_frames" should not exist
+      And there should be exactly 1 gif in "~/.lolcommits/animate"
 
   @fake-no-ffmpeg
   Scenario: gracefully fail when ffmpeg not installed and --animate is used

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -21,75 +21,42 @@ Feature: Basic UI functionality
     Then the output should not match /\-a\, \-\-animate\=SECONDS/
 
   Scenario: Enable in a naked git repo
-    Given a git repo named "loltest" with no "post-commit" hook
-    When I cd to "loltest"
-    And I successfully run `lolcommits --enable`
+    Given I am in a git repo
+    When I successfully run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
-      And the output should contain:
-        """
-        (to remove later, you can use: lolcommits --disable)
-        """
-      And a file named ".git/hooks/post-commit" should exist
-      And the file ".git/hooks/post-commit" should contain:
-        """
-        lolcommits --capture
-        """
+      And the lolcommits post-commit hook should be properly installed
       And the exit status should be 0
 
   Scenario: Enable in a git repo that already has a post-commit hook
-    Given a git repo named "loltest" with a "post-commit" hook
-      And the "loltest" repo "post-commit" hook has content "#!/bin/sh\n\n/my/own/script"
-    When I cd to "loltest"
-    And I successfully run `lolcommits --enable`
+    Given I am in a git repo
+    And a post-commit hook with "#!/bin/sh\n\n/my/own/script"
+    When I successfully run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
-      And the output should contain:
-        """
-        (to remove later, you can use: lolcommits --disable)
-        """
-      And a file named ".git/hooks/post-commit" should exist
-      And the file ".git/hooks/post-commit" should contain "#!/bin/sh"
-      And the file ".git/hooks/post-commit" should contain "/my/own/script"
-      And the file ".git/hooks/post-commit" should contain "lolcommits --capture"
+      And the lolcommits post-commit hook should be properly installed
+      And the post-commit hook should contain "#!/bin/sh"
+      And the post-commit hook should contain "/my/own/script"
       And the exit status should be 0
 
   Scenario: Enable in a git repo that has post-commit hook with a bad shebang
-    Given a git repo named "loltest" with a "post-commit" hook
-      And the "loltest" repo "post-commit" hook has content "#!/bin/ruby"
-    When I cd to "loltest"
+    Given I am in a git repo
+    And a post-commit hook with "#!/bin/ruby"
     And I run `lolcommits --enable`
-    Then the output should contain "doesn't start with a good shebang"
-      And the file ".git/hooks/post-commit" should not contain:
-        """
-        lolcommits --capture
-        """
+      Then the output should contain "doesn't start with a good shebang"
+      And the post-commit hook should not contain "lolcommits --capture"
       And the exit status should be 1
 
   Scenario: Enable in a git repo passing capture arguments
-    Given a git repo named "loltest" with no "post-commit" hook
-    When I cd to "loltest"
-    And I successfully run `lolcommits --enable -w 5 --fork`
-    Then the output should contain "installed lolcommit hook to:"
-      And the output should contain:
-        """
-        (to remove later, you can use: lolcommits --disable)
-        """
-      And a file named ".git/hooks/post-commit" should exist
-      And the file ".git/hooks/post-commit" should contain:
-        """
-        lolcommits --capture -w 5 --fork
-        """
-      And the exit status should be 0
+    Given I am in a git repo
+    When I successfully run `lolcommits --enable -w 5 --fork`
+    Then the post-commit hook should contain "lolcommits --capture -w 5 --fork"
+    And the exit status should be 0
 
   Scenario: Disable in a enabled git repo
-    Given I am in a git repo named "lolenabled" with lolcommits enabled
+    Given I am in a git repo with lolcommits enabled
     When I successfully run `lolcommits --disable`
     Then the output should contain "uninstalled"
-      And a file named ".git/hooks/post-commit" should exist
-      And the file ".git/hooks/post-commit" should not contain:
-        """
-        lolcommits --capture
-        """
-      And the exit status should be 0
+    And a file named ".git/hooks/post-commit" should exist
+    And the exit status should be 0
 
   Scenario: Trying to enable while not in a git repo fails
     Given I am in a directory named "svnrulez"

--- a/features/plugins.feature
+++ b/features/plugins.feature
@@ -6,14 +6,15 @@ Feature: Plugins Work
   @slow_process @unstable
   Scenario: Lolcommits.com integration works
     Given I am in a git repo named "dot_com" with lolcommits enabled
-    When I run `lolcommits --config` and wait for output
-    And I enter "dot_com" for "Plugin Name"
-    And I enter "true" for "enabled"
-    And I enter "b2a70ac0b64e012fa61522000a8c42dc" for "api_key"
-    And I enter "b2a720b0b64e012fa61522000a8c42dc" for "api_secret"
-    And I enter "c4aed530b64e012fa61522000a8c42dc" for "repo_id"
-    Then I should be presented "Successfully configured plugin: dot_com"
-    When I do a git commit
-    Then the output should contain "*** Preserving this moment in history."
-    And there should be exactly 1 jpg in "../.lolcommits/dot_com"
-
+    When I run `lolcommits --config` interactively
+      And I wait for output to contain "Name of plugin to configure:"
+      Then I type "dot_com"
+      And I wait for output to contain "enabled:"
+      Then I type "true"
+      And I wait for output to contain "api_key:"
+      Then I type "b2a70ac0b64e012fa61522000a8c42dc"
+      And I wait for output to contain "api_secret:"
+      Then I type "b2a70ac0b64e012fa61522000a8c42dc"
+      And I wait for output to contain "repo_id:"
+      Then I type "b2a70ac0b64e012fa61522000a8c42dc"
+    Then the output should contain "Successfully configured plugin: dot_com"

--- a/features/plugins.feature
+++ b/features/plugins.feature
@@ -5,7 +5,7 @@ Feature: Plugins Work
 
   @slow_process @unstable
   Scenario: Lolcommits.com integration works
-    Given I am in a git repository named "dot_com" with lolcommits enabled
+    Given I am in a git repo named "dot_com" with lolcommits enabled
     When I run `lolcommits --config` and wait for output
     And I enter "dot_com" for "Plugin Name"
     And I enter "true" for "enabled"
@@ -18,7 +18,7 @@ Feature: Plugins Work
     And there should be exactly 1 jpg in "../.lolcommits/dot_com"
 
   Scenario: Disable loltext
-    Given I am in a git repository named "loltext" with lolcommits enabled
+    Given I am in a git repo named "loltext" with lolcommits enabled
     And I run `lolcommits --config` and wait for output
     And I enter "loltext" for "Plugin Name"
     And I enter "false" for "enabled"
@@ -28,7 +28,7 @@ Feature: Plugins Work
     And there should be exactly 1 jpg in "../.lolcommits/loltext"
 
   Scenario: lolsrv integration works
-    Given I am in a git repository named "lolsrv" with lolcommits enabled
+    Given I am in a git repo named "lolsrv" with lolcommits enabled
     When I run `lolcommits --config` and wait for output
     And I enter "lolsrv" for "Plugin Name"
     And I enter "true" for "enabled"

--- a/features/plugins.feature
+++ b/features/plugins.feature
@@ -1,5 +1,8 @@
 Feature: Plugins Work
 
+  Background:
+    Given a mocked home directory
+
   @slow_process @unstable
   Scenario: Lolcommits.com integration works
     Given I am in a git repository named "dot_com" with lolcommits enabled
@@ -34,4 +37,3 @@ Feature: Plugins Work
     When I do a git commit
     Then the output should contain "*** Preserving this moment in history."
     And there should be exactly 1 jpg in "../.lolcommits/lolsrv"
-

--- a/features/plugins.feature
+++ b/features/plugins.feature
@@ -17,23 +17,3 @@ Feature: Plugins Work
     Then the output should contain "*** Preserving this moment in history."
     And there should be exactly 1 jpg in "../.lolcommits/dot_com"
 
-  Scenario: Disable loltext
-    Given I am in a git repo named "loltext" with lolcommits enabled
-    And I run `lolcommits --config` and wait for output
-    And I enter "loltext" for "Plugin Name"
-    And I enter "false" for "enabled"
-    Then I should be presented "Successfully configured plugin: loltext"
-    When I do a git commit
-    Then the output should contain "*** Preserving this moment in history."
-    And there should be exactly 1 jpg in "../.lolcommits/loltext"
-
-  Scenario: lolsrv integration works
-    Given I am in a git repo named "lolsrv" with lolcommits enabled
-    When I run `lolcommits --config` and wait for output
-    And I enter "lolsrv" for "Plugin Name"
-    And I enter "true" for "enabled"
-    And I enter "http://localhost" for "server"
-    Then I should be presented "Successfully configured plugin: lolsrv"
-    When I do a git commit
-    Then the output should contain "*** Preserving this moment in history."
-    And there should be exactly 1 jpg in "../.lolcommits/lolsrv"

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -6,6 +6,14 @@ def postcommit_hook
   ".git/hooks/post-commit"
 end
 
+def default_repo
+  "mygit"
+end
+
+def default_loldir
+  absolute_path("~/.lolcommits/#{default_repo}")
+end
+
 Given(/^I am in a directory named "(.*?)"$/) do |dir_name|
   steps %Q{
     Given a directory named "#{dir_name}"
@@ -28,7 +36,7 @@ end
 
 Given(/^I am in a git repo$/) do
   steps %Q{
-    Given I am in a git repo named "standard"
+    Given I am in a git repo named "#{default_repo}"
   }
 end
 
@@ -41,7 +49,7 @@ end
 
 Given(/^I am in a git repo with lolcommits enabled$/) do
   steps %Q{
-    Given I am in a git repo named "standard" with lolcommits enabled
+    Given I am in a git repo named "#{default_repo}" with lolcommits enabled
   }
 end
 
@@ -70,6 +78,12 @@ Given(/^I have environment variable (.*?) set to (.*?)$/) do |var, value|
   set_env var, value
 end
 
+Given(/^its loldir has (\d+) lolimages$/) do |num_images|
+  steps %Q{
+    Given a loldir named "#{default_repo}" with #{num_images} lolimages
+  }
+end
+
 Given(/^a loldir named "(.*?)" with (\d+) lolimages$/) do |repo, num_images|
   loldir = absolute_path("~/.lolcommits/#{repo}")
   FileUtils.mkdir_p loldir
@@ -79,7 +93,13 @@ Given(/^a loldir named "(.*?)" with (\d+) lolimages$/) do |repo, num_images|
   end
 end
 
-Then(/^there should be (?:exactly|only) (.*?) (jpg|gif|pid)(?:s?) in "(.*?)"$/) do |n, type, folder|
+Then(/^there should be exactly (.*?) (jpg|gif|pid)s? in its loldir$/) do |n, type|
+  steps %Q{
+    Then there should be exactly #{n} #{type} in "#{default_loldir}"
+  }
+end
+
+Then(/^there should be exactly (.*?) (jpg|gif|pid)s? in "(.*?)"$/) do |n, type, folder|
   expect(Dir[absolute_path(folder, "*.#{type}")].count).to eq(n.to_i)
 end
 

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -2,6 +2,10 @@
 require 'fileutils'
 require 'aruba/api'
 
+def postcommit_hook
+  ".git/hooks/post-commit"
+end
+
 Given(/^I am in a directory named "(.*?)"$/) do |dir_name|
   steps %Q{
     Given a directory named "#{dir_name}"
@@ -15,29 +19,6 @@ Given(/^a git repo named "(.*?)"$/) do |repo_name|
   }
 end
 
-Given(/^the git repo named "(.*?)" has no "(.*?)" hook$/) do |repo, hook_name|
-  hook_file = File.join current_dir, repo, '.git', 'hooks', hook_name
-  FileUtils.delete(hook_file) if File.exists? hook_file
-end
-
-Given(/^the git repo named "(.*?)" has a "(.*?)" hook$/) do |repo, hook_name|
-  hook_file = File.join current_dir, repo, '.git', 'hooks', hook_name
-  FileUtils.touch(hook_file) if not File.exists? hook_file
-end
-
-Given(/^the "(.*?)" repo "(.*?)" hook has content "(.*?)"$/) do |repo, hook_name, hook_content|
-  step %{the git repo named "#{repo}" has a "#{hook_name}" hook}
-  hook_file = File.join current_dir, repo, '.git', 'hooks', hook_name
-  File.open(hook_file, 'w') { |f| f.write(hook_content) }
-end
-
-Given(/^a git repo named "(.*?)" with (a|no) "(.*?)" hook$/) do |repo, yesno_modifier, hook_name|
-  steps %Q{
-    Given a git repo named "#{repo}"
-    And the git repo named "#{repo}" has #{yesno_modifier} "#{hook_name}" hook
-  }
-end
-
 Given(/^I am in a git repo named "(.*?)"$/) do |repo|
   steps %Q{
     Given a git repo named "#{repo}"
@@ -45,10 +26,43 @@ Given(/^I am in a git repo named "(.*?)"$/) do |repo|
   }
 end
 
+Given(/^I am in a git repo$/) do
+  steps %Q{
+    Given I am in a git repo named "standard"
+  }
+end
+
 Given(/^I am in a git repo named "(.*?)" with lolcommits enabled$/) do |repo|
   steps %Q{
     Given I am in a git repo named "#{repo}"
     And I successfully run `lolcommits --enable`
+  }
+end
+
+Given(/^I am in a git repo with lolcommits enabled$/) do
+  steps %Q{
+    Given I am in a git repo named "standard" with lolcommits enabled
+  }
+end
+
+Given(/^a post\-commit hook with "(.*?)"$/) do |file_content|
+  steps %Q{
+    Given a file named "#{postcommit_hook}" with:
+      """
+      #{file_content}
+      """
+  }
+end
+
+Then(/^the lolcommits post\-commit hook should be properly installed$/) do
+  steps %Q{
+    Then the post-commit hook should contain "lolcommits --capture"
+  }
+end
+
+Then(/^the post\-commit hook (should|should not) contain "(.*?)"$/) do |should, content|
+  steps %Q{
+    Then the file "#{postcommit_hook}" #{should} contain "#{content}"
   }
 end
 

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -10,13 +10,9 @@ Given(/^I am in a directory named "(.*?)"$/) do |dir_name|
 end
 
 Given(/^a git repo named "(.*?)"$/) do |repo_name|
-  repo_dir = File.join current_dir, repo_name
-  FileUtils.mkdir_p repo_dir
-  Dir.chdir repo_dir do
-    system 'git init --quiet .'
-    system "git config user.name 'Testy McTesterson'"
-    system "git config user.email 'testy@tester.com'"
-  end
+  steps %Q{
+   Given I successfully run `git init --quiet "#{repo_name}"`
+  }
 end
 
 Given(/^the git repo named "(.*?)" has no "(.*?)" hook$/) do |repo, hook_name|

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -114,7 +114,7 @@ Then /^there should be (\d+) commit entries in the git log$/ do |n|
 end
 
 Given /^I am using a "(.*?)" platform$/ do |platform_name|
-  ENV['LOLCOMMITS_FAKEPLATFORM'] = platform_name
+  set_env 'LOLCOMMITS_FAKEPLATFORM', platform_name
 end
 
 When /^I wait for the child process to exit in "(.*?)"$/ do |repo_name|

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -70,12 +70,6 @@ Given(/^I have environment variable (.*?) set to (.*?)$/) do |var, value|
   set_env var, value
 end
 
-When(/^I run `(.*?)` and wait for output$/) do |command|
-  command = "cd #{current_dir} && #{command}"
-  @stdin, @stdout, @stderr = Open3.popen3(command)
-  @fields = {}
-end
-
 Given(/^a loldir named "(.*?)" with (\d+) lolimages$/) do |repo, num_images|
   loldir = absolute_path("~/.lolcommits/#{repo}")
   FileUtils.mkdir_p loldir

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -71,15 +71,6 @@ Given(/^a loldir named "(.*?)" with (\d+) lolimages$/) do |repo, num_images|
   end
 end
 
-Then(/^I should be (prompted for|presented) "(.*?)"$/) do |_, prompt|
-  expect(@stdout.read.to_s).to include(prompt)
-end
-
-When(/^I enter "(.*?)" for "(.*?)"$/) do |input, field|
-  @fields[field] = input
-  @stdin.puts input
-end
-
 Then(/^there should be (?:exactly|only) (.*?) (jpg|gif|pid)(?:s?) in "(.*?)"$/) do |n, type, folder|
   expect(n.to_i).to eq(Dir["#{current_dir}/#{folder}/*.#{type}"].count)
 end

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -77,16 +77,16 @@ When(/^I run `(.*?)` and wait for output$/) do |command|
 end
 
 Given(/^a loldir named "(.*?)" with (\d+) lolimages$/) do |repo, num_images|
-  loldir = "tmp/aruba/.lolcommits/#{repo}"
+  loldir = absolute_path("~/.lolcommits/#{repo}")
   FileUtils.mkdir_p loldir
   num_images.to_i.times do
-    random_hex = '%011x' % (rand * 0xfffffffffff)
-    cp 'test/images/test_image.jpg', File.join(loldir, "#{random_hex}.jpg")
+    hex = '%011x' % (rand * 0xfffffffffff)
+    FileUtils.cp 'test/images/test_image.jpg', File.join(loldir, "#{hex}.jpg")
   end
 end
 
 Then(/^there should be (?:exactly|only) (.*?) (jpg|gif|pid)(?:s?) in "(.*?)"$/) do |n, type, folder|
-  expect(n.to_i).to eq(Dir["#{current_dir}/#{folder}/*.#{type}"].count)
+  expect(Dir[absolute_path(folder, "*.#{type}")].count).to eq(n.to_i)
 end
 
 Then(/^the output should contain a list of plugins$/) do
@@ -123,5 +123,6 @@ Given(/^I am using a "(.*?)" platform$/) do |platform_name|
 end
 
 When(/^I wait for the child process to exit in "(.*?)"$/) do |repo_name|
-  sleep 0.1 while File.exist?("tmp/aruba/.lolcommits/#{repo_name}/lolcommits.pid")
+  pid_loc = absolute_path("~/.lolcommits/#{repo_name}/lolcommits.pid")
+  sleep 0.1 while File.exist?(pid_loc)
 end

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -17,12 +17,12 @@ end
 
 Given(/^the git repo named "(.*?)" has no "(.*?)" hook$/) do |repo, hook_name|
   hook_file = File.join current_dir, repo, '.git', 'hooks', hook_name
-  delete(hook_file) if File.exists? hook_file
+  FileUtils.delete(hook_file) if File.exists? hook_file
 end
 
 Given(/^the git repo named "(.*?)" has a "(.*?)" hook$/) do |repo, hook_name|
   hook_file = File.join current_dir, repo, '.git', 'hooks', hook_name
-  touch(hook_file) if not File.exists? hook_file
+  FileUtils.touch(hook_file) if not File.exists? hook_file
 end
 
 Given(/^the "(.*?)" repo "(.*?)" hook has content "(.*?)"$/) do |repo, hook_name, hook_content|
@@ -32,8 +32,10 @@ Given(/^the "(.*?)" repo "(.*?)" hook has content "(.*?)"$/) do |repo, hook_name
 end
 
 Given(/^a git repo named "(.*?)" with (a|no) "(.*?)" hook$/) do |repo, yesno_modifier, hook_name|
-  step %{a git repo named "#{repo}"}
-  step %{the git repo named "#{repo}" has #{yesno_modifier} "#{hook_name}" hook}
+  steps %Q{
+    Given a git repo named "#{repo}"
+    And the git repo named "#{repo}" has #{yesno_modifier} "#{hook_name}" hook
+  }
 end
 
 Given(/^I am in a git repo named "(.*?)"$/) do |repo|
@@ -88,14 +90,15 @@ end
 
 When(/^I do a git commit with commit message "(.*?)"$/) do |commit_msg|
   filename = Faker::Lorem.words(1).first
-  step %{a 98 byte file named "#{filename}"}
-  step %{I successfully run `git add #{filename}`}
-  step %{I successfully run `git commit -m "#{commit_msg}"`}
+  steps %Q{
+    Given a 98 byte file named "#{filename}"
+    And I successfully run `git add #{filename}`
+    And I successfully run `git commit -m "#{commit_msg}"`
+  }
 end
 
 When(/^I do a git commit$/) do
-  commit_msg = Faker::Lorem.sentence
-  step %{I do a git commit with commit message "#{commit_msg}"}
+  step %{I do a git commit with commit message "#{Faker::Lorem.sentence}"}
 end
 
 When(/^I do (\d+) git commits$/) do |n|

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -1,16 +1,17 @@
 # -*- encoding : utf-8 -*-
-include FileUtils
+require 'fileutils'
+require 'aruba/api'
 
-Given /^I am in a directory named "(.*?)"$/ do |dir_name|
+Given(/^I am in a directory named "(.*?)"$/) do |dir_name|
   steps %Q{
     Given a directory named "#{dir_name}"
     And I cd to "#{dir_name}"
   }
 end
 
-Given /^a git repository named "(.*?)"$/ do |repo_name|
+Given(/^a git repo named "(.*?)"$/) do |repo_name|
   repo_dir = File.join current_dir, repo_name
-  mkdir_p repo_dir
+  FileUtils.mkdir_p repo_dir
   Dir.chdir repo_dir do
     system 'git init --quiet .'
     system "git config user.name 'Testy McTesterson'"
@@ -18,105 +19,105 @@ Given /^a git repository named "(.*?)"$/ do |repo_name|
   end
 end
 
-Given /^the git repository named "(.*?)" has no "(.*?)" hook$/ do |repo_name, hook_name|
-  hook_file = File.join current_dir, repo_name, '.git', 'hooks', hook_name
+Given(/^the git repo named "(.*?)" has no "(.*?)" hook$/) do |repo, hook_name|
+  hook_file = File.join current_dir, repo, '.git', 'hooks', hook_name
   delete(hook_file) if File.exists? hook_file
 end
 
-Given /^the git repository named "(.*?)" has a "(.*?)" hook$/ do |repo_name, hook_name|
-  hook_file = File.join current_dir, repo_name, '.git', 'hooks', hook_name
+Given(/^the git repo named "(.*?)" has a "(.*?)" hook$/) do |repo, hook_name|
+  hook_file = File.join current_dir, repo, '.git', 'hooks', hook_name
   touch(hook_file) if not File.exists? hook_file
 end
 
-Given /^the "(.*?)" repository "(.*?)" hook has content "(.*?)"$/ do |repo_name, hook_name, hook_content|
-  step %{the git repository named "#{repo_name}" has a "#{hook_name}" hook}
-  hook_file = File.join current_dir, repo_name, '.git', 'hooks', hook_name
+Given(/^the "(.*?)" repo "(.*?)" hook has content "(.*?)"$/) do |repo, hook_name, hook_content|
+  step %{the git repo named "#{repo}" has a "#{hook_name}" hook}
+  hook_file = File.join current_dir, repo, '.git', 'hooks', hook_name
   File.open(hook_file, 'w') { |f| f.write(hook_content) }
 end
 
-Given /^a git repository named "(.*?)" with (a|no) "(.*?)" hook$/ do |repo_name, yesno_modifier, hook_name|
-  step %{a git repository named "#{repo_name}"}
-  step %{the git repository named "#{repo_name}" has #{yesno_modifier} "#{hook_name}" hook}
+Given(/^a git repo named "(.*?)" with (a|no) "(.*?)" hook$/) do |repo, yesno_modifier, hook_name|
+  step %{a git repo named "#{repo}"}
+  step %{the git repo named "#{repo}" has #{yesno_modifier} "#{hook_name}" hook}
 end
 
-Given /^I am in a git repository named "(.*?)"$/ do |repo_name|
+Given(/^I am in a git repo named "(.*?)"$/) do |repo|
   steps %Q{
-    Given a git repository named "#{repo_name}"
-    And I cd to "#{repo_name}"
+    Given a git repo named "#{repo}"
+    And I cd to "#{repo}"
   }
 end
 
-Given /^I am in a git repository named "(.*?)" with lolcommits enabled$/ do |repo_name|
+Given(/^I am in a git repo named "(.*?)" with lolcommits enabled$/) do |repo|
   steps %Q{
-    Given I am in a git repository named "#{repo_name}"
+    Given I am in a git repo named "#{repo}"
     And I successfully run `lolcommits --enable`
   }
 end
 
-Given /^I have environment variable (.*?) set to (.*?)$/ do |var, value|
+Given(/^I have environment variable (.*?) set to (.*?)$/) do |var, value|
   set_env var, value
 end
 
-When /^I run `(.*?)` and wait for output$/ do |command|
+When(/^I run `(.*?)` and wait for output$/) do |command|
   command = "cd #{current_dir} && #{command}"
   @stdin, @stdout, @stderr = Open3.popen3(command)
   @fields = {}
 end
 
-Given /^a loldir named "(.*?)" with (\d+) lolimages$/ do |repo_name, num_images|
-  loldir = "tmp/aruba/.lolcommits/#{repo_name}"
-  mkdir_p loldir
+Given(/^a loldir named "(.*?)" with (\d+) lolimages$/) do |repo, num_images|
+  loldir = "tmp/aruba/.lolcommits/#{repo}"
+  FileUtils.mkdir_p loldir
   num_images.to_i.times do
     random_hex = '%011x' % (rand * 0xfffffffffff)
     cp 'test/images/test_image.jpg', File.join(loldir, "#{random_hex}.jpg")
   end
 end
 
-Then /^I should be (prompted for|presented) "(.*?)"$/ do |_, prompt|
+Then(/^I should be (prompted for|presented) "(.*?)"$/) do |_, prompt|
   expect(@stdout.read.to_s).to include(prompt)
 end
 
-When /^I enter "(.*?)" for "(.*?)"$/ do |input, field|
+When(/^I enter "(.*?)" for "(.*?)"$/) do |input, field|
   @fields[field] = input
   @stdin.puts input
 end
 
-Then /^there should be (?:exactly|only) (.*?) (jpg|gif|pid)(?:s?) in "(.*?)"$/ do |n, type, folder|
+Then(/^there should be (?:exactly|only) (.*?) (jpg|gif|pid)(?:s?) in "(.*?)"$/) do |n, type, folder|
   expect(n.to_i).to eq(Dir["#{current_dir}/#{folder}/*.#{type}"].count)
 end
 
-Then /^the output should contain a list of plugins$/ do
+Then(/^the output should contain a list of plugins$/) do
   step %{the output should contain "Available plugins: "}
 end
 
-When /^I do a git commit with commit message "(.*?)"$/ do |commit_msg|
+When(/^I do a git commit with commit message "(.*?)"$/) do |commit_msg|
   filename = Faker::Lorem.words(1).first
   step %{a 98 byte file named "#{filename}"}
   step %{I successfully run `git add #{filename}`}
   step %{I successfully run `git commit -m "#{commit_msg}"`}
 end
 
-When /^I do a git commit$/ do
+When(/^I do a git commit$/) do
   commit_msg = Faker::Lorem.sentence
   step %{I do a git commit with commit message "#{commit_msg}"}
 end
 
-When /^I do (\d+) git commits$/ do |n|
+When(/^I do (\d+) git commits$/) do |n|
   n.to_i.times do
     step %{I do a git commit}
     sleep 0.1
   end
 end
 
-Then /^there should be (\d+) commit entries in the git log$/ do |n|
+Then(/^there should be (\d+) commit entries in the git log$/) do |n|
   sleep 1 # let the file writing catch up
   expect(n.to_i).to eq `git shortlog | grep -E '^[ ]+\w+' | wc -l`.chomp.to_i
 end
 
-Given /^I am using a "(.*?)" platform$/ do |platform_name|
+Given(/^I am using a "(.*?)" platform$/) do |platform_name|
   set_env 'LOLCOMMITS_FAKEPLATFORM', platform_name
 end
 
-When /^I wait for the child process to exit in "(.*?)"$/ do |repo_name|
+When(/^I wait for the child process to exit in "(.*?)"$/) do |repo_name|
   sleep 0.1 while File.exist?("tmp/aruba/.lolcommits/#{repo_name}/lolcommits.pid")
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,8 +8,6 @@ require 'fileutils'
 require File.join(File.expand_path(File.dirname(__FILE__)), 'path_helpers')
 include Lolcommits
 
-ENV['PATH'] = "#{File.expand_path(File.dirname(__FILE__) + '/../../bin')}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
-
 World(PathHelpers)
 
 Before do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -26,15 +26,17 @@ Before do
   set_env 'GIT_COMMITTER_EMAIL', author_email
 end
 
+# for tasks that may take an insanely long time (e.g. network related)
+# we should strive to not have any of these in our scenarios, naturally.
+Before('@slow_process') do
+  @aruba_io_wait_seconds = 5
+  @aruba_timeout_seconds = 60
+end
+
 # in order to fake an interactive rebase, we replace the editor with a script
 # to simply squash a few random commits. in this case, using lines 3-5.
 Before('@fake-interactive-rebase') do
   set_env 'GIT_EDITOR', "sed -i -e '3,5 s/pick/squash/g'"
-end
-
-Before('@slow_process') do
-  @aruba_io_wait_seconds = 5
-  @aruba_timeout_seconds = 60
 end
 
 # adjust the path so tests dont see a global imagemagick install
@@ -42,24 +44,15 @@ Before('@fake-no-imagemagick') do
   reject_paths_with_cmd('mogrify')
 end
 
-After('@fake-no-imagemagick') do
-  reset_path
-end
-
 # adjust the path so tests dont see a global ffmpeg install
 Before('@fake-no-ffmpeg') do
   reject_paths_with_cmd('ffmpeg')
-end
-
-After('@fake-no-ffmpeg') do
-  reset_path
 end
 
 # do test in temporary directory so our own git repo-ness doesn't affect it
 Before('@in-tempdir') do
   @dirs = [Dir.mktmpdir]
 end
-
 After('@in-tempdir') do
   FileUtils.rm_rf(@dirs.first)
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,15 +20,11 @@ Before do
   @original_fakecapture = ENV['LOLCOMMITS_FAKECAPTURE']
   ENV['LOLCOMMITS_FAKECAPTURE'] = '1'
 
-  # @original_loldir = ENV['LOLCOMMITS_DIR']
-  # ENV['LOLCOMMITS_DIR'] = File.expand_path( File.join(current_dir, ".lolcommits") )
-
   ENV['LAUNCHY_DRY_RUN'] = 'true'
 end
 
 After do
   ENV['LOLCOMMITS_FAKECAPTURE'] = @original_fakecapture
-  # ENV['LOLCOMMITS_DIR'] = @original_loldir
   ENV['LAUNCHY_DRY_RUN'] = nil
   ENV['LOLCOMMITS_FAKEPLATFORM'] = nil
 end
@@ -37,7 +33,6 @@ Before('@fake-interactive-rebase') do
   # in order to fake an interactive rebase,
   # we replace the editor with a script that simply squashes a few random commits
   @original_git_editor = ENV['GIT_EDITOR']
-  # ENV['GIT_EDITOR'] = "sed -i -e 'n;s/pick/squash/g'" #every other commit
   ENV['GIT_EDITOR'] = "sed -i -e '3,5 s/pick/squash/g'" # lines 3-5
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -9,7 +9,6 @@ require File.join(File.expand_path(File.dirname(__FILE__)), 'path_helpers')
 include Lolcommits
 
 ENV['PATH'] = "#{File.expand_path(File.dirname(__FILE__) + '/../../bin')}#{File::PATH_SEPARATOR}#{ENV['PATH']}"
-LIB_DIR = File.join(File.expand_path(File.dirname(__FILE__)), '..', '..', 'lib')
 
 World(PathHelpers)
 
@@ -18,26 +17,18 @@ Before do
   @puts = true
   @aruba_timeout_seconds = 20
 
-  @original_rubylib = ENV['RUBYLIB']
-  ENV['RUBYLIB'] = LIB_DIR + File::PATH_SEPARATOR + ENV['RUBYLIB'].to_s
-
   @original_fakecapture = ENV['LOLCOMMITS_FAKECAPTURE']
   ENV['LOLCOMMITS_FAKECAPTURE'] = '1'
 
   # @original_loldir = ENV['LOLCOMMITS_DIR']
   # ENV['LOLCOMMITS_DIR'] = File.expand_path( File.join(current_dir, ".lolcommits") )
 
-  @original_home = ENV['HOME']
-  ENV['HOME'] = File.expand_path(current_dir)
-
   ENV['LAUNCHY_DRY_RUN'] = 'true'
 end
 
 After do
-  ENV['RUBYLIB'] = @original_rubylib
   ENV['LOLCOMMITS_FAKECAPTURE'] = @original_fakecapture
   # ENV['LOLCOMMITS_DIR'] = @original_loldir
-  ENV['HOME'] = @original_home
   ENV['LAUNCHY_DRY_RUN'] = nil
   ENV['LOLCOMMITS_FAKEPLATFORM'] = nil
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,6 +17,13 @@ Before do
 
   set_env 'LOLCOMMITS_FAKECAPTURE', '1'
   set_env 'LAUNCHY_DRY_RUN', 'true'
+
+  author_name  = "Testy McTesterson"
+  author_email = "testy@tester.com"
+  set_env 'GIT_AUTHOR_NAME',     author_name
+  set_env 'GIT_COMMITTER_NAME',  author_name
+  set_env 'GIT_AUTHOR_EMAIL',    author_email
+  set_env 'GIT_COMMITTER_EMAIL', author_email
 end
 
 # in order to fake an interactive rebase, we replace the editor with a script

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,27 +17,14 @@ Before do
   @puts = true
   @aruba_timeout_seconds = 20
 
-  @original_fakecapture = ENV['LOLCOMMITS_FAKECAPTURE']
-  ENV['LOLCOMMITS_FAKECAPTURE'] = '1'
-
-  ENV['LAUNCHY_DRY_RUN'] = 'true'
+  set_env 'LOLCOMMITS_FAKECAPTURE', '1'
+  set_env 'LAUNCHY_DRY_RUN', 'true'
 end
 
-After do
-  ENV['LOLCOMMITS_FAKECAPTURE'] = @original_fakecapture
-  ENV['LAUNCHY_DRY_RUN'] = nil
-  ENV['LOLCOMMITS_FAKEPLATFORM'] = nil
-end
-
+# in order to fake an interactive rebase, we replace the editor with a script
+# to simply squash a few random commits. in this case, using lines 3-5.
 Before('@fake-interactive-rebase') do
-  # in order to fake an interactive rebase,
-  # we replace the editor with a script that simply squashes a few random commits
-  @original_git_editor = ENV['GIT_EDITOR']
-  ENV['GIT_EDITOR'] = "sed -i -e '3,5 s/pick/squash/g'" # lines 3-5
-end
-
-After('@fake-interactive-rebase') do
-  ENV['GIT_EDITOR'] = @original_git_editor
+  set_env 'GIT_EDITOR', "sed -i -e '3,5 s/pick/squash/g'"
 end
 
 Before('@slow_process') do

--- a/features/support/path_helpers.rb
+++ b/features/support/path_helpers.rb
@@ -1,10 +1,10 @@
 # -*- encoding : utf-8 -*-
 require 'fileutils'
+require 'aruba/api'
 require 'lolcommits/platform'
 
 module PathHelpers
   def reject_paths_with_cmd(cmd)
-    @original_path = ENV['PATH']
     # make a new subdir that still contains cmds
     tmpbindir = File.expand_path(File.join @dirs, 'bin')
     FileUtils.mkdir_p tmpbindir
@@ -23,7 +23,9 @@ module PathHelpers
 
     # add the temporary directory with git in it back into the path
     newpaths << tmpbindir
-    ENV['PATH'] = newpaths.join(File::PATH_SEPARATOR)
+
+    # use aruba/api set_env to set PATH, which will be automaticaly restored
+    set_env 'PATH', newpaths.join(File::PATH_SEPARATOR)
   end
 
   def preseve_cmds_in_path(cmds, tmpbindir)
@@ -33,9 +35,5 @@ module PathHelpers
         FileUtils.ln_s whichcmd, File.join(tmpbindir, File.basename(whichcmd))
       end
     end
-  end
-
-  def reset_path
-    ENV['PATH'] = @original_path
   end
 end


### PR DESCRIPTION
This is pretty much strictly cosmetic, but I was working with Aruba on a new project, and realized how much the more recent versions build-in a lot of the stuff I had manually hacked into our environment setup to get the tests working in a controlled way.

So, undoing that stuff and using built-in defaults to make things cleaner.  This shouldn't make anything faster, but it will make this part of the code significantly less daunting to dive into in the future.