### PR TITLE
Fix gem issues on earlier rubies

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -41,6 +41,9 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 184
 
+Performance/Sample:
+  Enabled: false
+
 # Offense count: 6
 Metrics/CyclomaticComplexity:
   Max: 10
@@ -155,7 +158,7 @@ Style/RedundantSelf:
 
 # Offense count: 1
 Style/RegexpLiteral:
-  MaxSlashes: 2
+   Enabled: false
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
  - 1.9.3
  - 2.0.0
  - 2.1.5
- - 2.2.0
+ - 2.2.1
  - ruby-head
 
 before_install:

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -73,9 +73,9 @@ end
 # IF --CAPTURE, DO CAPTURE
 #
 def do_capture
-  capture_delay   = Choice.choices[:delay]   || ENV['LOLCOMMITS_DELAY']   || 0
+  capture_delay   = Choice.choices[:delay] || ENV['LOLCOMMITS_DELAY'] || 0
   capture_stealth = Choice.choices[:stealth] || ENV['LOLCOMMITS_STEALTH'] || nil
-  capture_font    = Choice.choices[:font]    || ENV['LOLCOMMITS_FONT']    || nil
+  capture_font    = Choice.choices[:font] || ENV['LOLCOMMITS_FONT'] || nil
   capture_device  = default_device
 
   capture_options = {

--- a/lib/lolcommits/plugins/dot_com.rb
+++ b/lib/lolcommits/plugins/dot_com.rb
@@ -26,8 +26,7 @@ module Lolcommits
                                   :key   => configuration['api_key'],
                                   :t     => t,
                                   :token =>  Digest::SHA1.hexdigest(configuration['api_secret'] + t)
-                                }
-      )
+                                })
     rescue => e
       log_error(e, "ERROR: HTTMultiParty POST FAILED #{e.class} - #{e.message}")
     end

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -32,10 +32,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('mini_magick', '~> 3.8.1') # ~> 4+ fails with JRuby
   s.add_runtime_dependency('mime-types', '~> 1.25')   # ~> 2+ requires Ruby >= 1.9.2
   s.add_runtime_dependency('httparty', '~> 0.11.0')   # ~> 0.13+ requires Ruby >= 1.9.3
+  s.add_runtime_dependency('git', '=1.2.8')           # ~> 1.2.9 has issues with Ruby 1.8.7
   s.add_development_dependency('cucumber', '=1.3.19') # ~> 2+ requries Ruby >= 1.9.3
 
   # core
-  s.add_runtime_dependency('git', '~> 1.2.8')
   s.add_runtime_dependency('choice', '~> 0.1.6')
   s.add_runtime_dependency('launchy', '~> 2.4.3')
   s.add_runtime_dependency('methadone', '~> 1.8.0')

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('mini_magick', '~> 3.8.1') # ~> 4+ fails with JRuby
   s.add_runtime_dependency('mime-types', '~> 1.25')   # ~> 2+ requires Ruby >= 1.9.2
   s.add_runtime_dependency('httparty', '~> 0.11.0')   # ~> 0.13+ requires Ruby >= 1.9.3
+  s.add_development_dependency('cucumber', '=1.3.19') # ~> 2+ requries Ruby >= 1.9.3
 
   # core
   s.add_runtime_dependency('git', '~> 1.2.8')


### PR DESCRIPTION
Fixes issues resulting from the latest updates gems;

* Cucumber gem v2.0.0+ now requires Ruby 1.9.3 or higher
* git gem > 1.2.8 now has issues with Ruby 1.8.7
* rubocop has updated syntax checking defaults

fixed by;

* updated syntax issues identified by Rubocop
* locking cucumber to 1.3.19
* locking git to 1.2.8
* now testing on Ruby 2.2.1 on Travis CI
