### PR TITLE
fix windows platform detection

### DIFF
--- a/lib/lolcommits/platform.rb
+++ b/lib/lolcommits/platform.rb
@@ -32,7 +32,7 @@ module Lolcommits
     # Are we on a Windows platform?
     # @return Boolean
     def self.platform_windows?
-      !RUBY_PLATFORM.match(/(win|w)32/)
+      !RUBY_PLATFORM.match(/(win|w)32/).nil?
     end
 
     # Are we on a Cygwin platform?


### PR DESCRIPTION
Quickly fixes an issue with windows platform detection, and still conforms to Rubucop conditions.