### PR TITLE
fixing windows mini_magick escape issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
  - 1.9.3
  - 2.0.0
  - 2.1.5
- - 2.2.1
+ - 2.2.2
  - ruby-head
 
 before_install:

--- a/lib/core_ext/mini_magick/utilities.rb
+++ b/lib/core_ext/mini_magick/utilities.rb
@@ -1,0 +1,20 @@
+# -*- encoding : utf-8 -*-
+module CoreExt
+  module MiniMagick
+    module Utilities
+      class << self
+        # fixes issue introduced in this commit
+        # https://github.com/minimagick/minimagick/commit/65b6427395cbfe6
+        def windows_escape(cmdline)
+          '"' + cmdline.gsub(/\\(?=\\*\")/, '\\\\\\').gsub(/\"/, '\\"').gsub(/\\$/, '\\\\\\').gsub('%', '%%') + '"'
+        end
+      end
+    end
+  end
+end
+
+# To maintain MiniMagick compatibility on Windows for v3.8.1 we need this patch
+# If/when we upgrade MiniMagick to 4.2+ this patch can be removed
+# We are locked at v3.8.1 since MiniMagick 4+ dropped support for Ruby 1.8.7
+
+MiniMagick.send(:include, CoreExt::MiniMagick::Utilities)

--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift File.expand_path('.')
 
 require 'core_ext/class'
 require 'mini_magick'
+require 'core_ext/mini_magick/utilities'
 require 'fileutils'
 require 'git'
 require 'open3'

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -59,6 +59,6 @@ Gem::Specification.new do |s|
 
   if RUBY_VERSION >= '1.9.3'
     s.add_development_dependency('travis', '~> 1.7.4')
-    s.add_development_dependency('rubocop', '~> 0.28')
+    s.add_development_dependency('rubocop', '~> 0.30')
   end
 end


### PR DESCRIPTION
To maintain MiniMagick compatibility on Windows for v3.8.1 we need this patch.  

It fixes an issue that was [introduced in an earlier version](https://github.com/minimagick/minimagick/commit/65b6427395cbfe6) of MiniMagick, but was later fixed in 4+

We are locked at v3.8.1 since MiniMagick 4+ dropped support for Ruby 1.8.7. If/when we upgrade MiniMagick to 4.2+ this patch can be removed.

:rocket: (also bumps rubocop gem to 0.30 and travis tests on Ruby 2.2.2)