### PR TITLE
Fix windows post commit hook path

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -163,15 +163,21 @@ Choice.options do
   option :enable do
     long '--enable'
     short '-e'
-    action { Installation.do_enable }
     desc 'install lolcommits for this repo'
+    action do
+      Installation.do_enable
+      exit 0
+    end
   end
 
   option :disable do
     long '--disable'
     short '-d'
-    action { Installation.do_disable }
     desc 'uninstall lolcommits for this repo'
+    action do
+      Installation.do_disable
+      exit 0
+    end
   end
 
   option :capture do
@@ -314,27 +320,25 @@ load_local_plugins!
 #
 # Handle actions manually since choice seems weird
 #
-if !Choice.choices[:enable] || !Choice.choices[:disable]
-  if Choice.choices[:capture]
-    do_capture
-  elsif Choice.choices[:configure]
-    do_configure
-  elsif Choice.choices[:show_config]
-    puts configuration
-  elsif Choice.choices[:plugins]
-    configuration.puts_plugins
-  elsif Choice.choices[:devices]
-    puts Platform.device_list
-    puts "Specify a device with --device=\"{device name}\" "\
-         'or set the LOLCOMMITS_DEVICE env variable'
-  elsif Choice.choices[:last]
-    do_last
-  elsif Choice.choices[:browse]
-    Fatals.die_if_not_git_repo!
-    Launcher.open_folder(configuration.loldir)
-  elsif Choice.choices[:gif]
-    TimelapseGif.new(configuration).run(Choice.choices[:gif])
-  else
-    do_noargs
-  end
+if Choice.choices[:capture]
+  do_capture
+elsif Choice.choices[:configure]
+  do_configure
+elsif Choice.choices[:show_config]
+  puts configuration
+elsif Choice.choices[:plugins]
+  configuration.puts_plugins
+elsif Choice.choices[:devices]
+  puts Platform.device_list
+  puts "Specify a device with --device=\"{device name}\" "\
+    'or set the LOLCOMMITS_DEVICE env variable'
+elsif Choice.choices[:last]
+  do_last
+elsif Choice.choices[:browse]
+  Fatals.die_if_not_git_repo!
+  Launcher.open_folder(configuration.loldir)
+elsif Choice.choices[:gif]
+  TimelapseGif.new(configuration).run(Choice.choices[:gif])
+else
+  do_noargs
 end

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,2 +1,2 @@
 ---
-default: <%= (RUBY_PLATFORM =~ /darwin/) ? 'features' : '--tags ~@mac-only' %>
+default: <%= (RbConfig::CONFIG['host_os'] =~ /darwin/) ? 'features' : '--tags ~@mac-only' %>

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -9,14 +9,14 @@ Feature: Basic UI functionality
     And the banner should be present
 
   Scenario: Help should show the animate option on a Mac platform
-    Given I am using a "Mac" platform
+    Given I am using a "darwin" platform
     When I get help for "lolcommits"
     Then the following options should be documented:
       | --animate | which is optional |
       | -a        | which is optional |
 
   Scenario: Help should not show the animate option on a Windows plaftorm
-    Given I am using a "Windows" platform
+    Given I am using a "win32" platform
     When I get help for "lolcommits"
     Then the output should not match /\-a\, \-\-animate\=SECONDS/
 
@@ -242,7 +242,6 @@ Feature: Basic UI functionality
   Scenario: should generate an animated gif on the Mac platform
     Given I am in a git repo named "animate"
       And I do a git commit
-      And I am using a "Mac" platform
     When I run `lolcommits --capture --animate=1`
     Then the output should contain "*** Preserving this moment in history."
       And a directory named "~/.lolcommits/animate" should exist
@@ -252,10 +251,17 @@ Feature: Basic UI functionality
 
   @fake-no-ffmpeg
   Scenario: gracefully fail when ffmpeg not installed and --animate is used
-    Given I am using a "Mac" platform
+    Given I am using a "darwin" platform
     When I run `lolcommits --animate=3`
     Then the output should contain:
       """
       ffmpeg does not appear to be properly installed
       """
     And the exit status should be 1
+
+  Scenario: Enable on windows platform setting PATH in post-commit hook
+    Given I am using a "win32" platform
+      And I am in a git repo
+    When I successfully run `lolcommits --enable`
+    Then the post-commit hook should contain "set path"
+    And the exit status should be 0

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -132,8 +132,8 @@ Then(/^there should be (\d+) commit entries in the git log$/) do |n|
   expect(n.to_i).to eq `git shortlog | grep -E '^[ ]+\w+' | wc -l`.chomp.to_i
 end
 
-Given(/^I am using a "(.*?)" platform$/) do |platform_name|
-  set_env 'LOLCOMMITS_FAKEPLATFORM', platform_name
+Given(/^I am using a "(.*?)" platform$/) do |host_os_name|
+  set_env 'LOLCOMMITS_FAKE_HOST_OS', host_os_name
 end
 
 When(/^I wait for the child process to exit in "(.*?)"$/) do |repo_name|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,11 +15,13 @@ Before do
   @puts = true
   @aruba_timeout_seconds = 20
 
-  set_env 'LOLCOMMITS_FAKECAPTURE', '1'
+  # prevent launchy from opening gifs in tests
   set_env 'LAUNCHY_DRY_RUN', 'true'
+  set_env 'LOLCOMMITS_CAPTURER', 'CaptureFake'
 
   author_name  = 'Testy McTesterson'
   author_email = 'testy@tester.com'
+
   set_env 'GIT_AUTHOR_NAME',     author_name
   set_env 'GIT_COMMITTER_NAME',  author_name
   set_env 'GIT_AUTHOR_EMAIL',    author_email
@@ -53,6 +55,7 @@ end
 Before('@in-tempdir') do
   @dirs = [Dir.mktmpdir]
 end
+
 After('@in-tempdir') do
   FileUtils.rm_rf(@dirs.first)
 end

--- a/lib/lolcommits/installation.rb
+++ b/lib/lolcommits/installation.rb
@@ -68,11 +68,17 @@ module Lolcommits
       end
     end
 
-    def self.hook_script(_add_shebang = true)
+    def self.hook_script
       ruby_path     = Lolcommits::Platform.command_which('ruby', true)
       imagick_path  = Lolcommits::Platform.command_which('identify', true)
-      locale_export = "export LANG=\"#{ENV['LANG']}\"\n"
-      hook_export   = "export PATH=\"#{ruby_path}:#{imagick_path}:$PATH\"\n"
+
+      if Lolcommits::Platform.platform_windows?
+        hook_export = "set path \"#{ruby_path};#{imagick_path};%PATH%\"\n"
+      else
+        locale_export = "export LANG=\"#{ENV['LANG']}\"\n"
+        hook_export   = "export PATH=\"#{ruby_path}:#{imagick_path}:$PATH\"\n"
+      end
+
       capture_cmd   = 'lolcommits --capture'
       capture_args  = " #{ARGV[1..-1].join(' ')}" if ARGV.length > 1
 

--- a/lib/lolcommits/platform.rb
+++ b/lib/lolcommits/platform.rb
@@ -1,68 +1,63 @@
 # -*- encoding : utf-8 -*-
 require 'mini_magick'
+require 'rbconfig'
 
 module Lolcommits
   class Platform
     # A convenience name for the platform.  Mainly used for metaprogramming.
     # @return String
     def self.platform
-      if platform_fakeplatform?   then ENV['LOLCOMMITS_FAKEPLATFORM']
-      elsif platform_fakecapture? then 'Fake'
-      elsif platform_mac?         then 'Mac'
-      elsif platform_linux?       then 'Linux'
-      elsif platform_windows?     then 'Windows'
-      elsif platform_cygwin?      then 'Cygwin'
+      if platform_mac?        then 'Mac'
+      elsif platform_linux?   then 'Linux'
+      elsif platform_windows? then 'Windows'
+      elsif platform_cygwin?  then 'Cygwin'
       else
         fail 'Unknown / Unsupported Platform.'
       end
     end
 
+    # The capturer class constant to use
+    # @return Class
+    def self.capturer_class(animate = false)
+      Object.const_get('Lolcommits').const_get(
+        ENV['LOLCOMMITS_CAPTURER'] || "Capture#{platform}#{animate ? 'Animated' : nil}"
+      )
+    end
+
     # Are we on a Mac platform?
     # @return Boolean
     def self.platform_mac?
-      RUBY_PLATFORM.to_s.downcase.include?('darwin')
+      host_os.include?('darwin')
     end
 
     # Are we on a Linux platform?
     # @return Boolean
     def self.platform_linux?
-      RUBY_PLATFORM.to_s.downcase.include?('linux')
+      host_os.include?('linux')
     end
 
     # Are we on a Windows platform?
     # @return Boolean
     def self.platform_windows?
-      !RUBY_PLATFORM.match(/(win|w)32/).nil?
+      !host_os.match(/(win|w)32/).nil?
     end
 
     # Are we on a Cygwin platform?
     # @return Boolean
     def self.platform_cygwin?
-      RUBY_PLATFORM.to_s.downcase.include?('cygwin')
+      host_os.include?('cygwin')
     end
 
-    # Are we currently faking webcam capture for test purposes?
-    # @return Boolean
-    def self.platform_fakecapture?
-      (ENV['LOLCOMMITS_FAKECAPTURE'] == '1' || false)
-    end
-
-    # Are we currently overriding and faking the platform entirely?
-    # @todo possibly make this a private method?
-    # @return Boolean
-    def self.platform_fakeplatform?
-      ENV['LOLCOMMITS_FAKEPLATFORM']
+    # return host_os identifier from the RbConfig::CONFIG constant
+    # @return String
+    def self.host_os
+      ENV['LOLCOMMITS_FAKE_HOST_OS'] || RbConfig::CONFIG['host_os'].downcase
     end
 
     # Is the platform capable of capturing animated GIFs from webcam?
     # @return Boolean
     def self.can_animate?
-      # FIXME: this is currently matching against string instead of
-      # simply returning platform_mac? || platform_linux?
-      # This is not ideal... but otherwise overriding platform via
-      # LOLCOMMITS_FAKEPLATFORM when running cucumber tests won't work.
-      # We should come up with a better solution.
-      %w(Mac Linux).include? platform
+      platform_linux? || platform_mac?
     end
 
     # Is a valid install of imagemagick present on the system?

--- a/lib/lolcommits/platform.rb
+++ b/lib/lolcommits/platform.rb
@@ -4,24 +4,22 @@ require 'rbconfig'
 
 module Lolcommits
   class Platform
-    # A convenience name for the platform.  Mainly used for metaprogramming.
-    # @return String
-    def self.platform
-      if platform_mac?        then 'Mac'
-      elsif platform_linux?   then 'Linux'
-      elsif platform_windows? then 'Windows'
-      elsif platform_cygwin?  then 'Cygwin'
-      else
-        fail 'Unknown / Unsupported Platform.'
-      end
-    end
-
     # The capturer class constant to use
     # @return Class
     def self.capturer_class(animate = false)
-      Object.const_get('Lolcommits').const_get(
-        ENV['LOLCOMMITS_CAPTURER'] || "Capture#{platform}#{animate ? 'Animated' : nil}"
-      )
+      if ENV['LOLCOMMITS_CAPTURER']
+        const_get(ENV['LOLCOMMITS_CAPTURER'])
+      elsif platform_mac?
+        animate ? CaptureMacAnimated : CaptureMac
+      elsif platform_linux?
+        animate ? CaptureLinuxAnimated : CaptureLinux
+      elsif platform_windows?
+        CaptureWindows
+      elsif platform_cygwin?
+        CaptureCygwin
+      else
+        fail 'Unknown / Unsupported Platform.'
+      end
     end
 
     # Are we on a Mac platform?

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -80,7 +80,8 @@ module Lolcommits
       puts '*** Preserving this moment in history.' unless capture_stealth
       self.snapshot_loc = config.raw_image(image_file_type)
       self.main_image   = config.main_image(sha, image_file_type)
-      capturer = capturer_class.new(
+
+      capturer = Platform.capturer_class(animate?).new(
         :capture_device    => capture_device,
         :capture_delay     => capture_delay,
         :snapshot_location => snapshot_loc,
@@ -98,11 +99,10 @@ module Lolcommits
 
     private
 
-    def capturer_class
-      capturer_module = 'Lolcommits'
-      capturer_class  = "Capture#{Platform.platform}#{animate? ? 'Animated' : nil}"
-      Object.const_get(capturer_module).const_get(capturer_class)
-    end
+    # def capturer_class
+    #   capturer_module = 'Lolcommits'
+    #   Object.const_get(capturer_module).const_get(Platform.capturer_class(animate?))
+    # end
 
     def image_file_type
       animate? ? 'gif' : 'jpg'


### PR DESCRIPTION
Fixes the git post-commit hook we create on Windows boxes.  For windows the PATH must be set like so;

    set path "C:\Ruby21-x64\bin;C:\Program Files (x86)\ImageMagick-6.8.0-Q16;%PATH%"

Without this fix, the post commit hook fails right now.  I've tested this on Windows 10 (tech preview), Windows 8.1 (64bit) and Windows 7 (32bit).  Also regression tested on OSX and Ubuntu Linux.

The PR also contains a clean up to the enable/disable commands, on all platforms they wrongly output the noargs message every time.  Exiting earlier resolves this.

