### PR TITLE
Configurable loltext

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Install dependencies using your package manager of choice, for example in
 Ubuntu:
 
     sudo apt-get install mplayer imagemagick libmagickwand-dev
-    
+
 For Ubuntu 14.04 or newer, you need to manually install ffmpeg since it no longer ships with the default Ubuntu sources. [Downloads for ffmpeg](http://ffmpeg.org/download.html)
 
 Then install the gem with:
@@ -104,7 +104,6 @@ via environment variables like so;
   **requires ffmpeg**
 * `LOLCOMMITS_DELAY` (in seconds) set delay persistently (for slow webcams to
   warmup)
-* `LOLCOMMITS_FONT` set font file location for lolcommit text
 * `LOLCOMMITS_FORK` fork lolcommit runner (capture command forks to a new
   process, speedily returning you to your terminal)
 * `LOLCOMMITS_STEALTH` disable notification messages at commit time
@@ -116,12 +115,16 @@ in your repository's `.git/hooks/post-commit` file).
 * `--device=DEVICE` or `-d DEVICE`
 * `--animate=SECONDS` or `-a SECONDS`
 * `--delay=SECONDS` or `-w SECONDS`
-* `--font=FONT_PATH` or `-f FONT_PATH`
 * `--fork`
 * `--stealth`
 
-Use `lolcommits --devices` to list all attached video devices available for
-capturing. Read how to [configure commit
+To change the font (including point size, position & color), simply configure
+the default loltext plugin with this command:
+
+    lolcommits --config -p loltext
+
+You can use `lolcommits --devices` to list all attached video devices available
+for capturing. Read how to [configure commit
 capturing](https://github.com/mroth/lolcommits/wiki/Configure-Commit-Capturing)
 for more details.
 
@@ -149,9 +152,16 @@ animated lolcommit gif")
 
 ### Plugins
 
-There are a growing amount of plugins for lolcommits to enable things like
-Twitter upload, translating your commit messages to lolspeak, etc.  Check them
-out on the [plugins
+A growing number of plugins are now available allowing you to transform or share
+your lolcommits with others. The default plugin simply appends your commit
+message and sha to the captured image. Others can auto post to Twitter, Tumblr
+(and other services), or even translate your commit messages to
+[lolspeak](http://www.urbandictionary.com/define.php?term=lolspeak). They can be
+easily enabled, configured or disabled with our config command:
+
+    lolcommits --config
+
+Check them out on our [plugins
 page](https://github.com/mroth/lolcommits/wiki/Configuring-Plugins).
 
 ## Troubles?

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -72,14 +72,12 @@ end
 def do_capture
   capture_delay   = Choice.choices[:delay] || ENV['LOLCOMMITS_DELAY'] || 0
   capture_stealth = Choice.choices[:stealth] || ENV['LOLCOMMITS_STEALTH'] || nil
-  capture_font    = Choice.choices[:font] || ENV['LOLCOMMITS_FONT'] || nil
   capture_device  = default_device
 
   capture_options = {
     :capture_delay   => capture_delay,
     :capture_stealth => capture_stealth,
     :capture_device  => capture_device,
-    :font            => capture_font,
     :capture_animate => capture_animate,
     :config          => configuration
   }
@@ -265,12 +263,6 @@ Choice.options do
   option :debug do
     long '--debug'
     desc 'output debugging information'
-  end
-
-  option :font do
-    long '--font=FONT_PATH'
-    short '-f'
-    desc 'pass font file location'
   end
 
   option :gif do

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -114,30 +114,49 @@ Feature: Basic UI functionality
     When I successfully run `lolcommits --plugins`
     Then the output should contain a list of plugins
 
-  Scenario: Configuring plugin
+  Scenario: Configuring loltext plugin
     Given I am in a git repo named "config-test"
     When I run `lolcommits --config` interactively
       And I wait for output to contain "Name of plugin to configure:"
       Then I type "loltext"
       And I wait for output to contain "enabled:"
       Then I type "true"
+      And I wait for output to contain "color"
+      Then I type "red"
+      And I wait for output to contain "font"
+      Then I type "my-font.ttf"
+      And I wait for output to contain "position"
+      Then I type "SouthEast"
+      And I wait for output to contain "size"
+      Then I type "32"
+      And I wait for output to contain "stroke color"
+      Then I type "white"
+      And I wait for output to contain "sha text"
+      Then I type ""
+      Then I type ""
+      Then I type ""
+      Then I type ""
+      Then I type ""
     Then the output should contain "Successfully configured plugin: loltext"
-    And the output should contain a list of plugins
-    And a file named "~/.lolcommits/config-test/config.yml" should exist
+      And the output should contain a list of plugins
+      And a file named "~/.lolcommits/config-test/config.yml" should exist
     When I successfully run `lolcommits --show-config`
-    Then the output should match /loltext:\s+enabled: true/
+    Then the output should match /enabled: true/
+    And the output should match /:font: my-font\.ttf/
+    And the output should match /:size: 32/
+    And the output should match /:position: SouthEast/
+    And the output should match /:color: red/
+    And the output should match /:stroke_color: white/
 
-  Scenario: Configuring plugin in test mode affects test loldir not repo loldir
+  Scenario: Configuring loltext plugin in test mode affects test loldir not repo loldir
     Given I am in a git repo named "testmode-config-test"
-    When I run `lolcommits --config --test` interactively
-      And I wait for output to contain "Name of plugin to configure:"
-      Then I type "loltext"
+    When I run `lolcommits --config --test -p loltext` interactively
       And I wait for output to contain "enabled:"
-      Then I type "true"
+      Then I type "false"
     Then the output should contain "Successfully configured plugin: loltext"
     And a file named "~/.lolcommits/test/config.yml" should exist
     When I successfully run `lolcommits --test --show-config`
-    Then the output should match /loltext:\s+enabled: true/
+    Then the output should match /loltext:\s+enabled: false/
 
   Scenario: test capture should work regardless of whether in a git repo
     Given I am in a directory named "nothingtoseehere"

--- a/lib/lolcommits/capturer.rb
+++ b/lib/lolcommits/capturer.rb
@@ -3,7 +3,7 @@ module Lolcommits
   class Capturer
     include Methadone::CLILogging
 
-    attr_accessor :capture_device, :capture_delay, :snapshot_location, :font,
+    attr_accessor :capture_device, :capture_delay, :snapshot_location,
                   :video_location, :frames_location, :animated_duration
 
     def initialize(attributes = {})

--- a/lib/lolcommits/cli/fatals.rb
+++ b/lib/lolcommits/cli/fatals.rb
@@ -29,8 +29,8 @@ module Lolcommits
           end
         end
 
-        # make sure we can find the Impact truetype font
-        unless File.readable? File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'fonts', 'Impact.ttf')
+        # make sure we can find the default font
+        unless File.readable? Lolcommits::Loltext::DEFAULT_FONT_PATH
           fatal "Couldn't properly read Impact font from gem package, "\
                 'please file a bug?!'
           exit 1

--- a/lib/lolcommits/plugin.rb
+++ b/lib/lolcommits/plugin.rb
@@ -50,8 +50,8 @@ module Lolcommits
         print "#{option}: "
         val = parse_user_input(STDIN.gets.strip)
         # check enabled option isn't a String
-        if (option == 'enabled') && val.is_a?(String)
-          puts "Aborting - please enable with 'true' or 'false'"
+        if (option == 'enabled') && ![true, false].include?(val)
+          puts "Aborting - please respond with 'true' or 'false'"
           exit 1
         else
           acc.merge(option => val)
@@ -60,10 +60,15 @@ module Lolcommits
     end
 
     def parse_user_input(str)
+      # cater for bools, strings, ints and blanks
       if 'true'.casecmp(str) == 0
         true
       elsif 'false'.casecmp(str) == 0
         false
+      elsif str =~ /^[0-9]+$/
+        str.to_i
+      elsif str.strip.empty?
+        nil
       else
         str
       end

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -1,6 +1,8 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
   class Loltext < Plugin
+    DEFAULT_FONT_PATH = File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'fonts', 'Impact.ttf')
+
     def self.name
       'loltext'
     end
@@ -28,7 +30,7 @@ module Lolcommits
         c.stroke config_option(type, :stroke_color)
         c.fill config_option(type, :color)
         c.gravity position_transform(config_option(type, :position))
-        c.pointsize config_option(type, :size)
+        c.pointsize runner.animate? ? 24 : config_option(type, :size)
         c.font config_option(type, :font)
         c.annotate '0', string
       end
@@ -70,15 +72,15 @@ module Lolcommits
     def config_defaults
       {
         :message => {
-          :font     => default_font_path,
-          :size     => runner.animate? ? 24 : 48,
+          :font     => DEFAULT_FONT_PATH,
+          :size     => 48,
           :position => 'SW',
           :color    => 'white',
           :stroke_color => 'black'
         },
         :sha => {
-          :font     => default_font_path,
-          :size     => runner.animate? ? 20 : 32,
+          :font     => DEFAULT_FONT_PATH,
+          :size     => 32,
           :position => 'NE',
           :color    => 'white',
           :stroke_color => 'black'
@@ -97,7 +99,7 @@ module Lolcommits
 
     private
 
-    # explode psuedo-names for text positions
+    # explode psuedo-names for text position
     def position_transform(position)
       case position
       when 'NE'
@@ -111,10 +113,6 @@ module Lolcommits
       when 'C'
         'Center'
       end
-    end
-
-    def default_font_path
-      File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'fonts', 'Impact.ttf')
     end
 
     # do whatever is required to commit message to get it clean and ready for imagemagick

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -1,9 +1,8 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
   class Loltext < Plugin
-    def initialize(runner)
-      super
-      @font_location = runner ? runner.font : nil
+    def self.name
+      'loltext'
     end
 
     # enabled by default (if no configuration exists)
@@ -12,43 +11,111 @@ module Lolcommits
     end
 
     def run_postcapture
-      font_location = @font_location || File.join(Configuration::LOLCOMMITS_ROOT,
-                                                  'vendor',
-                                                  'fonts',
-                                                  'Impact.ttf')
-
       debug 'Annotating image via MiniMagick'
       image = MiniMagick::Image.open(runner.main_image)
-      image.combine_options do |c|
-        c.gravity 'SouthWest'
-        c.fill 'white'
-        c.stroke 'black'
-        c.strokewidth '2'
-        c.pointsize(runner.animate? ? '24' : '48')
-        c.interline_spacing '-9'
-        c.font font_location
-        c.annotate '0', clean_msg(runner.message)
-      end
-
-      image.combine_options do |c|
-        c.gravity 'NorthEast'
-        c.fill 'white'
-        c.stroke 'black'
-        c.strokewidth '2'
-        c.pointsize(runner.animate? ? '21' : '32')
-        c.font font_location
-        c.annotate '0', runner.sha
-      end
-
+      annotate(image, :message, clean_msg(runner.message))
+      annotate(image, :sha, runner.sha)
       debug "Writing changed file to #{runner.main_image}"
       image.write runner.main_image
     end
 
-    def self.name
-      'loltext'
+    def annotate(image, type, string)
+      debug("annotating #{type} text to image")
+
+      image.combine_options do |c|
+        c.strokewidth '2'
+        c.interline_spacing '-9'
+        c.stroke config_option(type, :stroke_color)
+        c.fill config_option(type, :color)
+        c.gravity position_transform(config_option(type, :position))
+        c.pointsize config_option(type, :size)
+        c.font config_option(type, :font)
+        c.annotate '0', string
+      end
+    end
+
+    def configure_options!
+      options = super
+      # ask user to configure text options when enabling
+      if options['enabled']
+        puts '------------------------------------------------------'
+        puts '  Text options '
+        puts
+        puts '  * blank options use the (default)'
+        puts '  * use full absolute path to fonts'
+        puts '  * valid positions are NE, NW, SE, SW, C (centered)'
+        puts '  * colors can be hex #FC0 value or a string \'white\''
+        puts '------------------------------------------------------'
+
+        options[:message] = configure_sub_options(:message)
+        options[:sha]     = configure_sub_options(:sha)
+      end
+      options
+    end
+
+    # TODO: consider this type of configuration prompting in the base Plugin
+    # class, working with hash of defaults
+    def configure_sub_options(type)
+      print "#{type} text:\n"
+      defaults = config_defaults[type]
+
+      # sort option keys since different `Hash#keys` varys across Ruby versions
+      defaults.keys.sort_by(&:to_s).reduce({}) do |acc, opt|
+        print "  #{opt.to_s.gsub('_', ' ')} (#{defaults[opt]}): "
+        val = parse_user_input(STDIN.gets.strip)
+        acc.merge(opt => val)
+      end
+    end
+
+    def config_defaults
+      {
+        :message => {
+          :font     => default_font_path,
+          :size     => runner.animate? ? 24 : 48,
+          :position => 'SW',
+          :color    => 'white',
+          :stroke_color => 'black'
+        },
+        :sha => {
+          :font     => default_font_path,
+          :size     => runner.animate? ? 20 : 32,
+          :position => 'NE',
+          :color    => 'white',
+          :stroke_color => 'black'
+        }
+      }
+    end
+
+    def config_option(type, option)
+      default_option = config_defaults[type][option]
+      if configuration[type]
+        configuration[type][option] || default_option
+      else
+        default_option
+      end
     end
 
     private
+
+    # explode psuedo-names for text positions
+    def position_transform(position)
+      case position
+      when 'NE'
+        'NorthEast'
+      when 'NW'
+        'NorthWest'
+      when 'SE'
+        'SouthEast'
+      when 'SW'
+        'SouthWest'
+      when 'C'
+        'Center'
+      end
+    end
+
+    def default_font_path
+      File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'fonts', 'Impact.ttf')
+    end
 
     # do whatever is required to commit message to get it clean and ready for imagemagick
     def clean_msg(text)

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -4,7 +4,7 @@ require 'lolcommits/platform'
 module Lolcommits
   class Runner
     attr_accessor :capture_delay, :capture_stealth, :capture_device, :message,
-                  :sha, :snapshot_loc, :main_image, :config, :font, :git_info,
+                  :sha, :snapshot_loc, :main_image, :config, :git_info,
                   :capture_animate
 
     include Methadone::CLILogging
@@ -85,7 +85,6 @@ module Lolcommits
         :capture_device    => capture_device,
         :capture_delay     => capture_delay,
         :snapshot_location => snapshot_loc,
-        :font              => font,
         :video_location    => config.video_loc,
         :frames_location   => config.frames_loc,
         :animated_duration => capture_animate

--- a/test/lolcommits_test.rb
+++ b/test/lolcommits_test.rb
@@ -18,7 +18,7 @@ class LolTest < MiniTest::Test
   # this will test the permissions but only locally, important before building a gem package!
   #
   def test_permissions
-    impact_perms     = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'fonts', 'Impact.ttf')).mode & 0777
+    impact_perms     = File.lstat(Lolcommits::Loltext::DEFAULT_FONT_PATH).mode & 0777
     imagesnap_perms  = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'ext', 'imagesnap', 'imagesnap')).mode & 0777
     videosnap_perms  = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'ext', 'videosnap', 'videosnap')).mode & 0777
     commandcam_perms = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'ext', 'CommandCam', 'CommandCam.exe')).mode & 0777


### PR DESCRIPTION
This PR allows you to configure the default loltext plugin with the following options to alter the appearance of the annotated text (both the commit message and sha). 

* color (hex or text)
* font (full path to a font file)
* position (NE,SW, SE, NW, C)
* size (point size for the font)
* stroke color (outline color)

===

The gif and lolcommit below show whats possible with this;

![configure-loltext](https://cloud.githubusercontent.com/assets/2095/8889178/12e5b9b8-32c7-11e5-8efa-2b47bf9bea03.gif)

![477015ad7e1](https://cloud.githubusercontent.com/assets/2095/8889179/14708d9e-32c7-11e5-9f0f-1965bf020d25.jpg)

===

Given we are using ImageMagick to [annotate text](http://www.imagemagick.org/Usage/text/#annotate), there are only so many things we can play around with.  For now I think this is a good start.  

In terms of positioning the text, the four corners work well, however centering text may require you to alter the font size depending on what font you've chosen, since ImageMagick attempts to interpret the text boundary automatically.

Note that in this PR I am removing the ability to specify a font using the `LOLCOMMITS_FONT` env var.  I think it is more appropriate that this setting is held in the loltext plugin config instead.  

If we merge, I'll update our wiki explaining all this (README already updated in this PR), and prepare a new gem point release with a new CHANGELOG!  

**Note**: This PR closes issue #148 

