### PR TITLE
added optional_authorization config for uploldz

### DIFF
--- a/lib/lolcommits/plugins/uploldz.rb
+++ b/lib/lolcommits/plugins/uploldz.rb
@@ -18,14 +18,17 @@ module Lolcommits
       else
         debug "Posting capture to #{configuration['endpoint']}"
         RestClient.post(configuration['endpoint'],
-                        {:file         => File.new(runner.main_image),
-                        :message      => runner.message,
-                        :repo         => runner.git_info.repo,
-                        :author_name  => runner.git_info.author_name,
-                        :author_email => runner.git_info.author_email,
-                        :sha          => runner.sha,
-                        :key          => configuration['optional_key']
-                        },{:Authorization=>configuration['optional_authorization']})
+                        {
+                          :file         => File.new(runner.main_image),
+                          :message      => runner.message,
+                          :repo         => runner.git_info.repo,
+                          :author_name  => runner.git_info.author_name,
+                          :author_email => runner.git_info.author_email,
+                          :sha          => runner.sha,
+                          :key          => configuration['optional_key']
+                        },
+                        :Authorization => configuration['optional_authorization']
+                       )
       end
     rescue => e
       log_error(e, "ERROR: RestClient POST FAILED #{e.class} - #{e.message}")

--- a/lib/lolcommits/plugins/uploldz.rb
+++ b/lib/lolcommits/plugins/uploldz.rb
@@ -7,7 +7,7 @@ module Lolcommits
 
     def initialize(runner)
       super
-      options.concat(%w(endpoint optional_key))
+      options.concat(%w(endpoint optional_key optional_authorization))
     end
 
     def run_postcapture
@@ -18,13 +18,14 @@ module Lolcommits
       else
         debug "Posting capture to #{configuration['endpoint']}"
         RestClient.post(configuration['endpoint'],
-                        :file         => File.new(runner.main_image),
+                        {:file         => File.new(runner.main_image),
                         :message      => runner.message,
                         :repo         => runner.git_info.repo,
                         :author_name  => runner.git_info.author_name,
                         :author_email => runner.git_info.author_email,
                         :sha          => runner.sha,
-                        :key          => configuration['optional_key'])
+                        :key          => configuration['optional_key']
+                        },{:Authorization=>configuration['optional_authorization']})
       end
     rescue => e
       log_error(e, "ERROR: RestClient POST FAILED #{e.class} - #{e.message}")


### PR DESCRIPTION
First of all thanks for this lovely software, my team and I are using it with great pleasure!
Today I tried to connect lolcommits to our backend API and noticed there was no possibility to pass an authorization key with uploldz. The config variable "optional_authorization" enables this behaviour. See http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html (chapter 14.8) for more information on the "Authorization" header field. 
I would love to see this pull request in the official lolcommits repo :)
Greetings from Germany
Felix Roos
