### PR TITLE
Add slack integration

### DIFF
--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -27,6 +27,7 @@ require 'lolcommits/plugins/lolsrv'
 require 'lolcommits/plugins/lol_yammer'
 require 'lolcommits/plugins/lol_protonet'
 require 'lolcommits/plugins/lol_tumblr'
+require 'lolcommits/plugins/lol_slack'
 
 # require runner after all the plugins have been required
 require 'lolcommits/runner'

--- a/lib/lolcommits/plugins/lol_slack.rb
+++ b/lib/lolcommits/plugins/lol_slack.rb
@@ -1,0 +1,67 @@
+# -*- encoding : utf-8 -*-
+require 'rest_client'
+
+SLACK_FILE_UPLOAD_URL = 'https://slack.com/api/files.upload'
+SLACK_RETRY_COUNT = 2
+
+module Lolcommits
+  class LolSlack < Plugin
+    def self.name
+      'slack'
+    end
+
+    def self.runner_order
+      :postcapture
+    end
+
+    def configured?
+      !configuration['access_token'].nil?
+    end
+
+    def configure
+      print "Open the URL below and issue a token for your user:\n"
+      print "https://api.slack.com/web\n"
+      print "Enter the generated token below, then press enter: (e.g. xxxx-xxxxxxxxx-xxxx) \n"
+      code = STDIN.gets.to_s.strip
+      print "Enter a comma-seperated list of channel IDs to post images in, then press enter: (e.g. C1234567890,C1234567890)\n"
+      channels = STDIN.gets.to_s.strip
+
+      { 'access_token' => code,
+        'channels' => channels }
+    end
+
+    def configure_options!
+      options = super
+      if options['enabled']
+        config = configure
+        options.merge!(config)
+      end
+      options
+    end
+
+    def run_postcapture
+      return unless valid_configuration?
+
+      retries = SLACK_RETRY_COUNT
+      begin
+
+        response = RestClient.post(
+          SLACK_FILE_UPLOAD_URL,
+          :file         => File.new(runner.main_image),
+          :token        => configuration['access_token'],
+          :filetype     => 'jpg',
+          :filename     => runner.sha,
+          :title        => runner.message + "[#{runner.git_info.repo}]",
+          :channels     => configuration['channels'])
+
+        debug response
+      rescue => e
+        retries -= 1
+        retry if retries > 0
+        puts "Posting to slack failed - #{e.message}"
+        puts 'Try running config again:'
+        puts "\tlolcommits --config --plugin slack"
+      end
+    end
+  end
+end


### PR DESCRIPTION
# lol-slack
This PR adds a new plugin that handles image upload to slack; to share the awesomeness with friends, coworkers and envious nemeses.

The upload is done using the [Slack Web API File Upload](https://api.slack.com/methods/files.upload). The files are stored on slack, and posted to a channel/several channels specified in the configuration. 

Heavily inspired by (read: copied from) lol-yammer and uploldz.

## Configuration
lol-slack needs a valid user token in order to function. You can generate a personal token via the [Slack Web API](https://api.slack.com/web).
Additionally, you can specify in which channels or private groups to which the images should be posted. Simply enter a comma-separated list of channel IDs.
```
lolcommits --config -p slack

Configuring plugin: slack
enabled: true
Open the URL below and issue a token for your user:
https://api.slack.com/web
Enter the generated token below, then press enter: (e.g. xxxx-xxxxxxxxx-xxxx)
[User Token]
Enter a comma-seperated list of channel IDs to post images in, then press enter: (e.g. C1234567890,C1234567890)
[Channel ID(s)]
```

## Notes
* At the time of writing, the master branch had 5 RuboCop offenses, and 1 failed feature test (On My Machine:tm:). This branch does not increase those numbers (On My Machine:tm:)
* Suggestions, nitpickings and flame-wars are welcome