### PR TITLE
Avoid invoking ruby if in a rebase

### DIFF
--- a/lib/lolcommits/installation.rb
+++ b/lib/lolcommits/installation.rb
@@ -84,7 +84,9 @@ module Lolcommits
 
       <<-EOS
 ### lolcommits hook (begin) ###
+if [ ! -d "$GIT_DIR/rebase-merge" ]; then
 #{locale_export}#{hook_export}#{capture_cmd}#{capture_args}
+fi
 ###  lolcommits hook (end)  ###
 EOS
     end


### PR DESCRIPTION
Invoking ruby and loading lolcommits can be very slow. For example, on my (fairly fast) machine:

```
$ time ruby -r lolcommits -e ''
ruby -r lolcommits -e ''  0.61s user 0.10s system 99% cpu 0.716 total
```

This isn't usually an issue for a single commit, but it makes lolcommits
impossible to use with a rebase-driven workflow.

This adds an if guard to the post-commit hook installer, which entirely
skips running ruby when in the middle of a rebase.

![](http://i.hawth.ca/u/2e1e088d143.gif)