### PR TITLE
Slow gif problem on mac

### DIFF
--- a/lib/lolcommits/capturer/capture_mac_animated.rb
+++ b/lib/lolcommits/capturer/capture_mac_animated.rb
@@ -9,14 +9,15 @@ module Lolcommits
       # capture the raw video with videosnap
       system_call "#{executable_path} -s 240 #{capture_device_string}#{capture_delay_string}-t #{animated_duration} --no-audio #{video_location} > /dev/null"
       return unless File.exist?(video_location)
+      # get fps for ffmpeg output stream configuration
+      fps = video_fps(video_location)
       # convert raw video to png frames with ffmpeg
-      system_call "ffmpeg -v quiet -i #{video_location} -t #{animated_duration} #{frames_location}/%09d.png"
+      system_call "ffmpeg -v quiet -i #{video_location} -t #{animated_duration} -r #{fps} #{frames_location}/%09d.png"
 
       # use fps to set delay and number of frames to skip (for lower filesized gifs)
-      fps   = video_fps(video_location)
       skip  = frame_skip(fps)
       delay = frame_delay(fps, skip)
-      debug "Capturer: anaimated gif choosing every #{skip} frames with a frame delay of #{delay}"
+      debug "Capturer: animated gif choosing every #{skip} frames with a frame delay of #{delay}"
 
       # create the looping animated gif from frames (picks nth frame with seq)
       seq_command = "seq -f #{frames_location}/%09g.png 1 #{skip} #{Dir["#{frames_location}/*"].length}"


### PR DESCRIPTION
I don't know why, ffmpeg started to generate strange output stream.

Input: 12.68 fps
Output: 60 fps
Result: very slow gif

I simply pass fps to ffmpeg. It worked for me.

```bash
ffmpeg version 2.8.3
````

```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'movie.mov':
  Metadata:
    major_brand     : qt
    minor_version   : 0
    compatible_brands: qt
    creation_time   : 2015-12-12 10:52:17
  Duration: 00:00:01.33, start: -1.032833, bitrate: 805 kb/s
    Stream #0:0(und): Video: h264 (Main) (avc1 / 0x31637661), yuv420p(tv, bt709), 320x240 [SAR 1:1 DAR 4:3], 428 kb/s, 12.68 fps, 60 tbr, 30k tbn, 60k tbc (default)
    Metadata:
      creation_time   : 2015-12-12 10:52:17
      handler_name    : Core Media Data Handler
      encoder         : H.264
Output #0, image2, to 'frames/%09d.png':
  Metadata:
    major_brand     : qt
    minor_version   : 0
    compatible_brands: qt
    encoder         : Lavf56.40.101
    Stream #0:0(und): Video: png, rgb24, 320x240 [SAR 1:1 DAR 4:3], q=2-31, 200 kb/s, 60 fps, 60 tbn, 60 tbc (default)
    Metadata:
      creation_time   : 2015-12-12 10:52:17
      handler_name    : Core Media Data Handler
      encoder         : Lavc56.60.100 png
Stream mapping:
  Stream #0:0 -> #0:0 (h264 (native) -> png (native))
Press [q] to stop, [?] for help
frame=  141 fps=0.0 q=-0.0 Lsize=N/A time=00:00:02.35 bitrate=N/A dup=111 drop=0
video:12906kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown
```