### PR TITLE
Peg RuboCop gem to 0.37.2 and fix any remaining cop issues

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ Rake::TestTask.new do |t|
 end
 
 Rake::FileUtilsExt.verbose(false)
-CUKE_RESULTS = 'results.html'
+CUKE_RESULTS = 'results.html'.freeze
 CLEAN << CUKE_RESULTS
 Cucumber::Rake::Task.new(:features) do |t|
   optstr = "features --format html -o #{CUKE_RESULTS} --format Fivemat -x"

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -95,7 +95,7 @@ def do_capture
       }
 
       # fire off runner with the overriden fake commit metadata
-      runner = Lolcommits::Runner.new(capture_options.merge override_text)
+      runner = Lolcommits::Runner.new(capture_options.merge(override_text))
       runner.run
 
       # automatically open so user can see the test image results immediately
@@ -322,8 +322,7 @@ elsif Choice.choices[:plugins]
   configuration.puts_plugins
 elsif Choice.choices[:devices]
   puts Platform.device_list
-  puts "Specify a device with --device=\"{device name}\" "\
-    'or set the LOLCOMMITS_DEVICE env variable'
+  puts 'Specify a device with --device="{device name}" or set the LOLCOMMITS_DEVICE env variable'
 elsif Choice.choices[:last]
   do_last
 elsif Choice.choices[:browse]

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -88,7 +88,7 @@ Given(/^a loldir named "(.*?)" with (\d+) lolimages$/) do |repo, num_images|
   loldir = absolute_path("~/.lolcommits/#{repo}")
   FileUtils.mkdir_p loldir
   num_images.to_i.times do
-    hex = "#{format '%011x', (rand * 0xfffffffffff)}"
+    hex = format('%011x', (rand * 0xfffffffffff)).to_s
     FileUtils.cp 'test/images/test_image.jpg', File.join(loldir, "#{hex}.jpg")
   end
 end

--- a/features/support/path_helpers.rb
+++ b/features/support/path_helpers.rb
@@ -6,7 +6,7 @@ require 'lolcommits/platform'
 module PathHelpers
   def reject_paths_with_cmd(cmd)
     # make a new subdir that still contains cmds
-    tmpbindir = File.expand_path(File.join @dirs, 'bin')
+    tmpbindir = File.expand_path(File.join(@dirs, 'bin'))
     FileUtils.mkdir_p tmpbindir
 
     preseve_cmds_in_path(%w(git mplayer), tmpbindir)

--- a/lib/lolcommits/capturer/capture_linux_animated.rb
+++ b/lib/lolcommits/capturer/capture_linux_animated.rb
@@ -45,7 +45,7 @@ module Lolcommits
 
     def frame_skip(fps)
       # of frames to skip depends on movie fps
-      case (fps)
+      case fps
       when 0..15
         2
       when 16..28

--- a/lib/lolcommits/capturer/capture_mac_animated.rb
+++ b/lib/lolcommits/capturer/capture_mac_animated.rb
@@ -50,7 +50,7 @@ module Lolcommits
 
     def frame_skip(fps)
       # of frames to skip depends on movie fps
-      case (fps)
+      case fps
       when 0..15
         2
       when 16..28

--- a/lib/lolcommits/cli/timelapse_gif.rb
+++ b/lib/lolcommits/cli/timelapse_gif.rb
@@ -36,7 +36,7 @@ module Lolcommits
         gif = MiniMagick::Image.new File.join @configuration.archivedir, filename
 
         # This is for ruby 1.8.7, *lolimages just doesn't work with ruby 187
-        gif.run_command('convert', *['-delay', '50', '-loop', '0', lolimages, "#{gif.path}"].flatten)
+        gif.run_command('convert', *['-delay', '50', '-loop', '0', lolimages, gif.path.to_s].flatten)
 
         puts "*** #{gif.path} generated."
       end

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -35,11 +35,11 @@ module Lolcommits
     end
 
     def most_recent
-      Dir.glob(File.join loldir, '*.{jpg,gif}').max_by { |f| File.mtime(f) }
+      Dir.glob(File.join(loldir, '*.{jpg,gif}')).max_by { |f| File.mtime(f) }
     end
 
     def jpg_images
-      Dir.glob(File.join loldir, '*.jpg').sort_by { |f| File.mtime(f) }
+      Dir.glob(File.join(loldir, '*.jpg')).sort_by { |f| File.mtime(f) }
     end
 
     def jpg_images_today

--- a/lib/lolcommits/platform.rb
+++ b/lib/lolcommits/platform.rb
@@ -18,7 +18,7 @@ module Lolcommits
       elsif platform_cygwin?
         CaptureCygwin
       else
-        fail 'Unknown / Unsupported Platform.'
+        raise 'Unknown / Unsupported Platform.'
       end
     end
 

--- a/lib/lolcommits/plugins/dot_com.rb
+++ b/lib/lolcommits/plugins/dot_com.rb
@@ -3,7 +3,7 @@ require 'httmultiparty'
 
 module Lolcommits
   class DotCom < Plugin
-    BASE_URL = 'http://lolcommits-dot-com.herokuapp.com'
+    BASE_URL = 'http://lolcommits-dot-com.herokuapp.com'.freeze
 
     def initialize(runner)
       super

--- a/lib/lolcommits/plugins/lol_slack.rb
+++ b/lib/lolcommits/plugins/lol_slack.rb
@@ -3,7 +3,7 @@ require 'rest_client'
 
 module Lolcommits
   class LolSlack < Plugin
-    ENDPOINT_URL = 'https://slack.com/api/files.upload'
+    ENDPOINT_URL = 'https://slack.com/api/files.upload'.freeze
     RETRY_COUNT  = 2
 
     def self.name

--- a/lib/lolcommits/plugins/lol_tumblr.rb
+++ b/lib/lolcommits/plugins/lol_tumblr.rb
@@ -7,9 +7,9 @@ require 'tumblr_client'
 
 module Lolcommits
   class LolTumblr < Plugin
-    TUMBLR_API_ENDPOINT    = 'https://www.tumblr.com'
-    TUMBLR_CONSUMER_KEY    = '2FtMEDpEPkxjoUdkpHh42h9wqTu9IVS7Ra0QyNZGixdCvhllN2'
-    TUMBLR_CONSUMER_SECRET = 'qWuvxgFUR2YyWKtbWOkDTMAiBEbj7ZGaNLaNQPba0PI1N4JpBs'
+    TUMBLR_API_ENDPOINT    = 'https://www.tumblr.com'.freeze
+    TUMBLR_CONSUMER_KEY    = '2FtMEDpEPkxjoUdkpHh42h9wqTu9IVS7Ra0QyNZGixdCvhllN2'.freeze
+    TUMBLR_CONSUMER_SECRET = 'qWuvxgFUR2YyWKtbWOkDTMAiBEbj7ZGaNLaNQPba0PI1N4JpBs'.freeze
 
     def run_postcapture
       return unless valid_configuration?
@@ -29,11 +29,8 @@ module Lolcommits
       # ask user to configure tokens if enabling
       if options['enabled']
         auth_config = configure_auth!
-        if auth_config
-          options = options.merge(auth_config).merge(configure_tumblr_name)
-        else
-          return # return nil if configure_auth failed
-        end
+        return unless auth_config
+        options = options.merge(auth_config).merge(configure_tumblr_name)
       end
       options
     end

--- a/lib/lolcommits/plugins/lol_twitter.rb
+++ b/lib/lolcommits/plugins/lol_twitter.rb
@@ -5,12 +5,12 @@ require 'twitter'
 
 module Lolcommits
   class LolTwitter < Plugin
-    TWITTER_API_ENDPOINT    = 'https://api.twitter.com'
-    TWITTER_CONSUMER_KEY    = 'qc096dJJCxIiqDNUqEsqQ'
-    TWITTER_CONSUMER_SECRET = 'rvjNdtwSr1H0TvBvjpk6c4bvrNydHmmbvv7gXZQI'
+    TWITTER_API_ENDPOINT    = 'https://api.twitter.com'.freeze
+    TWITTER_CONSUMER_KEY    = 'qc096dJJCxIiqDNUqEsqQ'.freeze
+    TWITTER_CONSUMER_SECRET = 'rvjNdtwSr1H0TvBvjpk6c4bvrNydHmmbvv7gXZQI'.freeze
     TWITTER_RETRIES         = 2
     TWITTER_PIN_REGEX       = /^\d{4,}$/ # 4 or more digits
-    DEFAULT_SUFFIX          = '#lolcommits'
+    DEFAULT_SUFFIX          = '#lolcommits'.freeze
 
     def run_postcapture
       return unless valid_configuration?
@@ -50,11 +50,8 @@ module Lolcommits
       # ask user to configure tokens if enabling
       if options['enabled']
         auth_config = configure_auth!
-        if auth_config
-          options = options.merge(auth_config).merge(configure_prefix_suffix)
-        else
-          return # return nil if configure_auth failed
-        end
+        return unless auth_config
+        options = options.merge(auth_config).merge(configure_prefix_suffix)
       end
       options
     end

--- a/lib/lolcommits/plugins/lol_yammer.rb
+++ b/lib/lolcommits/plugins/lol_yammer.rb
@@ -3,9 +3,9 @@ require 'yammer'
 require 'rest_client'
 
 # https://developer.yammer.com/oauth2-quickstart/
-YAMMER_CLIENT_ID        = 'bgORyeKtnjZJSMwp8oln9g'
-YAMMER_CLIENT_SECRET    = 'oer2WdGzh74a5QBbW3INUxblHK3yg9KvCZmiBa2r0'
-YAMMER_ACCESS_TOKEN_URL = 'https://www.yammer.com/oauth2/access_token.json'
+YAMMER_CLIENT_ID        = 'bgORyeKtnjZJSMwp8oln9g'.freeze
+YAMMER_CLIENT_SECRET    = 'oer2WdGzh74a5QBbW3INUxblHK3yg9KvCZmiBa2r0'.freeze
+YAMMER_ACCESS_TOKEN_URL = 'https://www.yammer.com/oauth2/access_token.json'.freeze
 YAMMER_RETRY_COUNT      = 2
 
 module Lolcommits
@@ -28,7 +28,7 @@ module Lolcommits
       print 'Enter code param from the redirected URL, then press enter: '
       code = STDIN.gets.to_s.strip
 
-      url = "#{YAMMER_ACCESS_TOKEN_URL}"
+      url = YAMMER_ACCESS_TOKEN_URL
       debug "access_token url: #{url}"
       params = {
         'client_id' => YAMMER_CLIENT_ID,
@@ -47,11 +47,8 @@ module Lolcommits
       # ask user to configure tokens if enabling
       if options['enabled']
         auth_config = configure_access_token
-        if auth_config
-          options.merge!(auth_config)
-        else
-          return # return nil if configure_auth failed
-        end
+        return unless auth_config
+        options.merge!(auth_config)
       end
       options
     end

--- a/lib/lolcommits/plugins/tranzlate.rb
+++ b/lib/lolcommits/plugins/tranzlate.rb
@@ -27,7 +27,6 @@ module Lolspeak
     /want/             => %w(wants),
     /ead\b/            => %w(edd),
     /ck/               => %w(kk kkk),
-    /sion/             => %w(shun),
     /cat|kitten|kitty/ => %w(kitteh kittehz cat fuzzeh fuzzyrumpus foozles fuzzbut fluffernutter beast mew),
     /eak/              => %w(ekk),
     /age/              => %w(uj),
@@ -79,7 +78,7 @@ module Lolspeak
     /can\si\s(?:ple(?:a|e)(?:s|z)e?)?\s?have\sa/ => ['i can haz'],
     /(?:hello|\bhi\b|\bhey\b|howdy|\byo\b),?/    => ['oh hai,'],
     /(?:god\b|allah|buddah?|diety|lord)/         => ['ceiling cat']
-  }
+  }.freeze
 
   def tranzlate(str)
     lolstr = str.dup

--- a/lib/lolcommits/plugins/uploldz.rb
+++ b/lib/lolcommits/plugins/uploldz.rb
@@ -8,12 +8,14 @@ module Lolcommits
 
     def initialize(runner)
       super
-      options.concat(%w(
-        endpoint
-        optional_key
-        optional_http_auth_username
-        optional_http_auth_password
-      ))
+      options.concat(
+        %w(
+          endpoint
+          optional_key
+          optional_http_auth_username
+          optional_http_auth_password
+        )
+      )
     end
 
     def run_postcapture

--- a/lib/lolcommits/version.rb
+++ b/lib/lolcommits/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
-  VERSION = '0.6.1'
+  VERSION = '0.6.1'.freeze
 end

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -62,6 +62,6 @@ Gem::Specification.new do |s|
 
   if RUBY_VERSION >= '1.9.3'
     s.add_development_dependency('travis', '~> 1.7.4')
-    s.add_development_dependency('rubocop', '~> 0.35')
+    s.add_development_dependency('rubocop', '~> 0.37.2')
   end
 end


### PR DESCRIPTION
Updates the Rubocop gem to the latest version and pegs it in the gemspec to `0.37.2`, so we don't get future Rubocop issues in later PRs.

Also fixes any remaining Rubocop issues, mostly `freeze`-ing constants across the codebase.