### PR TITLE
Added plugin config path to output

### DIFF
--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -94,7 +94,7 @@ module Lolcommits
         config[plugin_name] = plugin_config
         save(config)
         puts self
-        puts "\nSuccessfully configured plugin: #{plugin_name}"
+        puts "\nSuccessfully configured plugin: #{plugin_name} at path '#{configuration_file}'"
       else
         puts "\nAborted plugin configuration for: #{plugin_name}"
       end


### PR DESCRIPTION
After enabling a new plugin the user sees the configuration, but it's not clear that this was already written to the filesystem