### PR TITLE
Adds quotes to correctly handle paths with spaces

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,7 +21,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 92
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:
-  Max: 157
+  Max: 159
 
 # Offense count: 24
 # Configuration parameters: CountComments.

--- a/lib/lolcommits/capturer/capture_mac_animated.rb
+++ b/lib/lolcommits/capturer/capture_mac_animated.rb
@@ -7,7 +7,7 @@ module Lolcommits
       FileUtils.mkdir_p(frames_location)
 
       # capture the raw video with videosnap
-      system_call "#{executable_path} -s 240 #{capture_device_string}#{capture_delay_string}-t #{animated_duration} --no-audio #{video_location} > /dev/null"
+      system_call "#{executable_path} -s 240 #{capture_device_string}#{capture_delay_string}-t #{animated_duration} --no-audio '#{video_location}' > /dev/null"
       return unless File.exist?(video_location)
       # get fps for ffmpeg output stream configuration
       fps = video_fps(video_location)


### PR DESCRIPTION
Hey,

I noticed that when creating videosnaps (lolcommits as gifs) the file path is not properly enclosed and hence this happens:

```
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `/Users/pedrocunha/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/lolcommits-0.6.2/lib/lolcommits/../../vendor/ext/videosnap/videosnap -s 240 -t 5 --no-audio /Users/pedrocunha/Dropbox (Pedro)/lolcommits/orderweb/tmp_video.mov > /dev/null'
```

Properly enclosing the file-path fixes the issue.
