### PR TITLE
Fix animated capture with spaced dir

### DIFF
--- a/lib/lolcommits/capturer/capture_linux_animated.rb
+++ b/lib/lolcommits/capturer/capture_linux_animated.rb
@@ -18,10 +18,12 @@ module Lolcommits
       delay = frame_delay(fps, skip)
       debug "Capturer: anaimated gif choosing every #{skip} frames with a frame delay of #{delay}"
 
-      # create the looping animated gif from frames (picks nth frame with seq)
-      seq_command = "seq -f \"#{frames_location}/%09g.png\" 1 #{skip} #{Dir["#{frames_location}/*"].length}"
+      # create the looping animated gif from frames (picks nth frame with seq,
+      # quotes output and concats to a single line with tr)
+      seq_command = "seq -f \"\\\"#{frames_location}/%09g.png\\\"\" 1 #{skip} #{Dir["#{frames_location}/*"].length} | tr '\\n' ' '"
+      seq_frame_files = system_call(seq_command, true)
       # convert to animated gif with delay and gif optimisation
-      system_call "convert -layers OptimizeTransparency -delay #{delay} -loop 0 `#{seq_command}` -coalesce \"#{snapshot_location}\" > /dev/null"
+      system_call "convert -layers OptimizeTransparency -delay #{delay} -loop 0 #{seq_frame_files} -coalesce \"#{snapshot_location}\""
     end
 
     private
@@ -39,7 +41,7 @@ module Lolcommits
 
     def video_fps(file)
       # inspect fps of the captured video file (default to 29.97)
-      fps = system_call("ffmpeg -i #{file} 2>&1 | sed -n \"s/.*, \\(.*\\) fp.*/\\1/p\"", true)
+      fps = system_call("ffmpeg -i \"#{file}\" 2>&1 | sed -n \"s/.*, \\(.*\\) fp.*/\\1/p\"", true)
       fps.to_i < 1 ? 29.97 : fps.to_f
     end
 


### PR DESCRIPTION
This PR fixes issues with animated gif capturing when using a `LOLCOMMITS_DIR` that has spaces in its path.  Some extra file path escaping was necessary and the output from the `seq` command that grabs frames, must be one-lined.

Fixed on both mac and linux animated capturers, and tested on OSX/Ubuntu.  Thanks to @pedrocunha for pointing out this issue and helping to debug.