### PR TITLE
Add Mercurial support

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -136,9 +136,7 @@ def change_dir_to_root_or_repo!
       warn 'Repository root not found'
       return
     end
-    if VCSInfo.is_repo_root?
-      return
-    end
+    return if VCSInfo.repo_root?
     Dir.chdir(nxt)
   end
 end

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -304,6 +304,8 @@ Fatals.die_on_fatal_platform_conditions!
 #
 change_dir_to_root_or_repo!
 
+# TODO: Allow local backend definitions?
+
 #
 # load system local plugins
 #

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -113,7 +113,7 @@ def do_configure
 end
 
 def do_last
-  Fatals.die_if_not_git_repo!
+  Fatals.die_if_not_vcs_repo!
   lolimage = configuration.most_recent
   if lolimage.nil?
     warn 'No lolcommits have been captured for this repository yet.'
@@ -136,8 +136,8 @@ def change_dir_to_root_or_repo!
       warn 'Repository root not found'
       return
     end
-    if File.directory?(File.expand_path('.git')) || File.directory?(File.expand_path('.hg'))
-      return # found root or git dir
+    if VCSInfo.is_repo_root?
+      return
     end
     Dir.chdir(nxt)
   end
@@ -332,7 +332,7 @@ elsif Choice.choices[:devices]
 elsif Choice.choices[:last]
   do_last
 elsif Choice.choices[:browse]
-  Fatals.die_if_not_git_repo!
+  Fatals.die_if_not_vcs_repo!
   Launcher.open_folder(configuration.loldir)
 elsif Choice.choices[:gif]
   TimelapseGif.new(configuration).run(Choice.choices[:gif])

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -132,7 +132,11 @@ def change_dir_to_root_or_repo!
   loop do
     cur = File.expand_path('.')
     nxt = File.expand_path('..', cur)
-    if File.directory?(File.expand_path('.git')) || nxt == cur
+    if nxt == cur
+      warn 'Repository root not found'
+      return
+    end
+    if File.directory?(File.expand_path('.git')) || File.directory?(File.expand_path('.hg'))
       return # found root or git dir
     end
     Dir.chdir(nxt)

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -24,31 +24,31 @@ Feature: Basic UI functionality
     Given I am in a git repo
     When I successfully run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
-      And the lolcommits post-commit hook should be properly installed
+      And the lolcommits git post-commit hook should be properly installed
       And the exit status should be 0
 
-  Scenario: Enable in a git repo that already has a post-commit hook
+  Scenario: Enable in a git repo that already has a git post-commit hook
     Given I am in a git repo
-    And a post-commit hook with "#!/bin/sh\n\n/my/own/script"
+    And a git post-commit hook with "#!/bin/sh\n\n/my/own/script"
     When I successfully run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
-      And the lolcommits post-commit hook should be properly installed
-      And the post-commit hook should contain "#!/bin/sh"
-      And the post-commit hook should contain "/my/own/script"
+      And the lolcommits git post-commit hook should be properly installed
+      And the git post-commit hook should contain "#!/bin/sh"
+      And the git post-commit hook should contain "/my/own/script"
       And the exit status should be 0
 
-  Scenario: Enable in a git repo that has post-commit hook with a bad shebang
+  Scenario: Enable in a git repo that has git post-commit hook with a bad shebang
     Given I am in a git repo
-    And a post-commit hook with "#!/bin/ruby"
+    And a git post-commit hook with "#!/bin/ruby"
     And I run `lolcommits --enable`
       Then the output should contain "doesn't start with a good shebang"
-      And the post-commit hook should not contain "lolcommits --capture"
+      And the git post-commit hook should not contain "lolcommits --capture"
       And the exit status should be 1
 
   Scenario: Enable in a git repo passing capture arguments
     Given I am in a git repo
     When I successfully run `lolcommits --enable -w 5 --fork`
-    Then the post-commit hook should contain "lolcommits --capture -w 5 --fork"
+    Then the git post-commit hook should contain "lolcommits --capture -w 5 --fork"
     And the exit status should be 0
 
   Scenario: Disable in a enabled git repo
@@ -63,7 +63,7 @@ Feature: Basic UI functionality
     When I run `lolcommits --enable`
     Then the output should contain:
       """
-      You don't appear to be in the base directory of a git project.
+      You don't appear to be in the base directory of a supported vcs project.
       """
     And the exit status should be 1
 
@@ -77,7 +77,7 @@ Feature: Basic UI functionality
       And a file named "~/.lolcommits/forked/tmp_snapshot.jpg" should not exist
       And there should be exactly 1 jpg in "~/.lolcommits/forked"
 
-  Scenario: Commiting in an enabled repo triggers successful capture
+  Scenario: Commiting in an enabled git repo triggers successful capture
     Given I am in a git repo named "myrepo" with lolcommits enabled
     When I do a git commit
     Then the output should contain "*** Preserving this moment in history."
@@ -85,7 +85,7 @@ Feature: Basic UI functionality
       And a file named "~/.lolcommits/myrepo/tmp_snapshot.jpg" should not exist
       And there should be exactly 1 jpg in "~/.lolcommits/myrepo"
 
-  Scenario: Commiting in enabled repo subdirectory triggers successful capture
+  Scenario: Commiting in enabled git repo subdirectory triggers successful capture
     Given I am in a git repo named "testcapture" with lolcommits enabled
       And a directory named "subdir"
       And an empty file named "subdir/FOOBAR"
@@ -158,7 +158,7 @@ Feature: Basic UI functionality
     When I successfully run `lolcommits --test --show-config`
     Then the output should match /loltext:\s+enabled: false/
 
-  Scenario: test capture should work regardless of whether in a git repo
+  Scenario: test capture should work regardless of whether in a lolrepo
     Given I am in a directory named "nothingtoseehere"
     When I run `lolcommits --test --capture`
     Then the output should contain "*** Capturing in test mode."
@@ -171,13 +171,13 @@ Feature: Basic UI functionality
     Then a directory named "~/.lolcommits/test" should exist
     And a directory named "~/.lolcommits/randomgitrepo" should not exist
 
-  Scenario: last command should work properly when in a lolrepo
+  Scenario: last command should work properly when in a git lolrepo
     Given I am in a git repo
     And its loldir has 2 lolimages
     When I run `lolcommits --last`
     Then the exit status should be 0
 
-  Scenario: last command should work properly when in a lolrepo subdirectory
+  Scenario: last command should work properly when in a git lolrepo subdirectory
     Given I am in a git repo
       And its loldir has 2 lolimages
       And a directory named "randomdir"
@@ -185,7 +185,7 @@ Feature: Basic UI functionality
     When I run `lolcommits --last`
     Then the output should not contain:
       """
-      Can't do that since we're not in a valid git repository!
+      Unknown VCS
       """
     And the exit status should be 0
 
@@ -195,7 +195,7 @@ Feature: Basic UI functionality
     When I run `lolcommits --last`
     Then the output should contain:
       """
-      Can't do that since we're not in a valid git repository!
+      Unknown VCS
       """
     And the exit status should be 1
 
@@ -209,13 +209,13 @@ Feature: Basic UI functionality
       """
     Then the exit status should be 1
 
-  Scenario: browse command should work properly when in a lolrepo
+  Scenario: browse command should work properly when in a git lolrepo
     Given I am in a git repo
     And its loldir has 2 lolimages
     When I run `lolcommits --browse`
     Then the exit status should be 0
 
-  Scenario: browse command should work properly when in a lolrepo subdirectory
+  Scenario: browse command should work properly when in a git lolrepo subdirectory
     Given I am in a git repo
       And its loldir has 2 lolimages
       And a directory named "subdir"
@@ -223,7 +223,7 @@ Feature: Basic UI functionality
     When I run `lolcommits --browse`
     Then the output should not contain:
       """
-      Can't do that since we're not in a valid git repository!
+      Unknown VCS
       """
     And the exit status should be 0
 
@@ -233,11 +233,11 @@ Feature: Basic UI functionality
     When I run `lolcommits --browse`
     Then the output should contain:
       """
-      Can't do that since we're not in a valid git repository!
+      Unknown VCS
       """
     And the exit status should be 1
 
-  Scenario: handle commit messages with quotation marks
+  Scenario: handle git commit messages with quotation marks
     Given I am in a git repo with lolcommits enabled
     When I successfully run `git commit --allow-empty -m 'no "air quotes" bae'`
     Then the exit status should be 0
@@ -278,9 +278,101 @@ Feature: Basic UI functionality
       """
     And the exit status should be 1
 
-  Scenario: Enable on windows platform setting PATH in post-commit hook
+  Scenario: Enable on windows platform setting PATH in git post-commit hook
     Given I am using a "win32" platform
       And I am in a git repo
     When I successfully run `lolcommits --enable`
-    Then the post-commit hook should contain "set path"
+    Then the git post-commit hook should contain "set path"
     And the exit status should be 0
+
+  Scenario: Enable in a naked mercurial repo
+    Given I am in a mercurial repo
+    When I successfully run `lolcommits --enable`
+    Then the output should contain "installed lolcommit hook to:"
+    And the lolcommits mercurial post-commit hook should be properly installed
+    And the exit status should be 0
+
+  Scenario: Enable in a mercurial repo that already has a mercurial post-commit hook
+    Given I am in a mercurial repo
+    And a mercurial post-commit hook with "[hooks]\npost-commit.mine = /my/own/script"
+    When I successfully run `lolcommits --enable`
+    Then the output should contain "installed lolcommit hook to:"
+    And the lolcommits mercurial post-commit hook should be properly installed
+    And the mercurial post-commit hook should contain "post-commit.mine = /my/own/script"
+    And the exit status should be 0
+
+  Scenario: Enable in a mercurial repo passing capture arguments
+    Given I am in a mercurial repo
+    When I successfully run `lolcommits --enable -w 5 --fork`
+    Then the mercurial post-commit hook should contain "lolcommits --capture -w 5 --fork"
+    And the exit status should be 0
+
+  Scenario: Disable in a enabled mercurial repo
+    Given I am in a mercurial repo with lolcommits enabled
+    When I successfully run `lolcommits --disable`
+    Then the output should contain "uninstalled"
+    And a file named ".hg/hgrc" should exist
+    And the exit status should be 0
+
+  Scenario: Commiting in an enabled mercurial repo triggers successful capture
+    Given I am in a mercurial repo named "myrepo" with lolcommits enabled
+    When I do a mercurial commit
+    Then the output should contain "*** Preserving this moment in history."
+    And a directory named "~/.lolcommits/myrepo" should exist
+    And a file named "~/.lolcommits/myrepo/tmp_snapshot.jpg" should not exist
+    And there should be exactly 1 jpg in "~/.lolcommits/myrepo"
+
+  Scenario: Commiting in enabled mercurial repo subdirectory triggers successful capture
+    Given I am in a mercurial repo named "testcapture" with lolcommits enabled
+    And a directory named "subdir"
+    And an empty file named "subdir/FOOBAR"
+    When I cd to "subdir/"
+    And I do a mercurial commit
+    Then the output should contain "*** Preserving this moment in history."
+    And a directory named "~/.lolcommits/testcapture" should exist
+    And a directory named "~/.lolcommits/subdir" should not exist
+    And there should be exactly 1 jpg in "~/.lolcommits/testcapture"
+
+  Scenario: last command should work properly when in a mercurial lolrepo
+    Given I am in a mercurial repo
+    And its loldir has 2 lolimages
+    When I run `lolcommits --last`
+    Then the exit status should be 0
+
+  Scenario: last command should work properly when in a mercurial lolrepo subdirectory
+    Given I am in a mercurial repo
+    And its loldir has 2 lolimages
+    And a directory named "randomdir"
+    And I cd to "randomdir"
+    When I run `lolcommits --last`
+    Then the output should not contain:
+      """
+      Unknown VCS
+      """
+    And the exit status should be 0
+
+  Scenario: browse command should work properly when in a mercurial lolrepo
+    Given I am in a mercurial repo
+    And its loldir has 2 lolimages
+    When I run `lolcommits --browse`
+    Then the exit status should be 0
+
+  Scenario: browse command should work properly when in a mercurial lolrepo subdirectory
+    Given I am in a mercurial repo
+    And its loldir has 2 lolimages
+    And a directory named "subdir"
+    And I cd to "subdir"
+    When I run `lolcommits --browse`
+    Then the output should not contain:
+      """
+      Unknown VCS
+      """
+    And the exit status should be 0
+
+  Scenario: handle mercurial commit messages with quotation marks
+    Given I am in a mercurial repo with lolcommits enabled
+    When I successfully run `touch meh`
+    And I successfully run `hg add meh`
+    And I successfully run `hg commit -m 'no "air quotes" bae'`
+    Then the exit status should be 0
+    And there should be exactly 1 jpg in its loldir

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -2,12 +2,16 @@
 require 'fileutils'
 require 'aruba/api'
 
-def postcommit_hook
+def postcommit_hook_git
   '.git/hooks/post-commit'
 end
 
+def postcommit_hook_mercurial
+  '.hg/hgrc'
+end
+
 def default_repo
-  'mygit'
+  'myrepo'
 end
 
 def default_loldir
@@ -53,24 +57,77 @@ Given(/^I am in a git repo with lolcommits enabled$/) do
     )
 end
 
-Given(/^a post\-commit hook with "(.*?)"$/) do |file_content|
+Given(/^a git post\-commit hook with "(.*?)"$/) do |file_content|
   steps %(
-    Given a file named "#{postcommit_hook}" with:
+    Given a file named "#{postcommit_hook_git}" with:
       """
       #{file_content}
       """
     )
 end
 
-Then(/^the lolcommits post\-commit hook should be properly installed$/) do
+Then(/^the lolcommits git post\-commit hook should be properly installed$/) do
   steps %(
-    Then the post-commit hook should contain "lolcommits --capture"
+    Then the git post-commit hook should contain "lolcommits --capture"
     )
 end
 
-Then(/^the post\-commit hook (should|should not) contain "(.*?)"$/) do |should, content|
+Then(/^the git post\-commit hook (should|should not) contain "(.*?)"$/) do |should, content|
   steps %(
-    Then the file "#{postcommit_hook}" #{should} contain "#{content}"
+    Then the file "#{postcommit_hook_git}" #{should} contain "#{content}"
+    )
+end
+
+Given(/^a mercurial repo named "(.*?)"$/) do |repo_name|
+  steps %(
+   Given I successfully run `hg init "#{repo_name}"`
+    )
+end
+
+Given(/^I am in a mercurial repo named "(.*?)"$/) do |repo|
+  steps %(
+    Given a mercurial repo named "#{repo}"
+    And I cd to "#{repo}"
+    )
+end
+
+Given(/^I am in a mercurial repo$/) do
+  steps %(
+    Given I am in a mercurial repo named "#{default_repo}"
+    )
+end
+
+Given(/^I am in a mercurial repo named "(.*?)" with lolcommits enabled$/) do |repo|
+  steps %(
+    Given I am in a mercurial repo named "#{repo}"
+    And I successfully run `lolcommits --enable`
+    )
+end
+
+Given(/^I am in a mercurial repo with lolcommits enabled$/) do
+  steps %(
+    Given I am in a mercurial repo named "#{default_repo}" with lolcommits enabled
+    )
+end
+
+Given(/^a mercurial post\-commit hook with "(.*?)"$/) do |file_content|
+  steps %(
+    Given a file named "#{postcommit_hook_mercurial}" with:
+      """
+      #{file_content}
+      """
+    )
+end
+
+Then(/^the lolcommits mercurial post\-commit hook should be properly installed$/) do
+  steps %(
+    Then the mercurial post-commit hook should contain "lolcommits --capture"
+    )
+end
+
+Then(/^the mercurial post\-commit hook (should|should not) contain "(.*?)"$/) do |should, content|
+  steps %(
+    Then the file "#{postcommit_hook_mercurial}" #{should} contain "#{content}"
     )
 end
 
@@ -130,6 +187,31 @@ end
 Then(/^there should be (\d+) commit entries in the git log$/) do |n|
   sleep 1 # let the file writing catch up
   expect(n.to_i).to eq `git shortlog | grep -E '^[ ]+\w+' | wc -l`.chomp.to_i
+end
+
+When(/^I do a mercurial commit with commit message "(.*?)"$/) do |commit_msg|
+  filename = Faker::Lorem.words(1).first
+  steps %(
+    Given a 98 byte file named "#{filename}"
+    And I successfully run `hg add #{filename}`
+    And I successfully run `hg commit -m "#{commit_msg}"`
+    )
+end
+
+When(/^I do a mercurial commit$/) do
+  step %(I do a mercurial commit with commit message "#{Faker::Lorem.sentence}")
+end
+
+When(/^I do (\d+) mercurial commits$/) do |n|
+  n.to_i.times do
+    step %(I do a mercurial commit)
+    sleep 0.1
+  end
+end
+
+Then(/^there should be (\d+) commit entries in the mercurial log$/) do |n|
+  sleep 1 # let the file writing catch up
+  expect(n.to_i).to eq `hg log | grep '^changeset:' | wc -l`.chomp.to_i
 end
 
 Given(/^I am using a "(.*?)" platform$/) do |host_os_name|

--- a/lib/core_ext/string.rb
+++ b/lib/core_ext/string.rb
@@ -1,0 +1,9 @@
+# -*- encoding : utf-8 -*-
+if RUBY_VERSION =~ /^1\.8/
+  class String
+    # used unconditionally by mercurial-ruby
+    def encode(str, _options)
+      str
+    end
+  end
+end

--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -9,17 +9,21 @@ require 'git'
 require 'open3'
 require 'methadone'
 require 'date'
+require 'mercurial-ruby'
 
 require 'lolcommits/version'
 require 'lolcommits/configuration'
 require 'lolcommits/capturer'
-require 'lolcommits/git_info'
+require 'lolcommits/vcs_info'
 require 'lolcommits/installation'
 require 'lolcommits/plugin'
 require 'lolcommits/platform'
 
 # backends
 require 'lolcommits/backends/installation_git'
+require 'lolcommits/backends/installation_mercurial'
+require 'lolcommits/backends/git_info'
+require 'lolcommits/backends/mercurial_info'
 
 require 'lolcommits/plugins/loltext'
 require 'lolcommits/plugins/dot_com'

--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -2,6 +2,7 @@
 $LOAD_PATH.unshift File.expand_path('.')
 
 require 'core_ext/class'
+require 'core_ext/string'
 require 'mini_magick'
 require 'core_ext/mini_magick/utilities'
 require 'fileutils'

--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -18,6 +18,9 @@ require 'lolcommits/installation'
 require 'lolcommits/plugin'
 require 'lolcommits/platform'
 
+# backends
+require 'lolcommits/backends/installation_git'
+
 require 'lolcommits/plugins/loltext'
 require 'lolcommits/plugins/dot_com'
 require 'lolcommits/plugins/tranzlate'

--- a/lib/lolcommits/backends/git_info.rb
+++ b/lib/lolcommits/backends/git_info.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
-  class GitInfo
+  class GitInfo < VCSInfo
     include Methadone::CLILogging
     attr_accessor :sha, :message, :repo_internal_path, :repo, :url,
                   :author_name, :author_email, :branch

--- a/lib/lolcommits/backends/git_info.rb
+++ b/lib/lolcommits/backends/git_info.rb
@@ -7,6 +7,10 @@ module Lolcommits
 
     GIT_URL_REGEX = %r{.*[:]([\/\w\-]*).git}
 
+    def self.is_repo_root?(path='.')
+      Dir.exists?(File.join(path, '.git'))
+    end
+
     def initialize
       debug 'GitInfo: parsed the following values from commit:'
       debug "GitInfo: \t#{message}"

--- a/lib/lolcommits/backends/git_info.rb
+++ b/lib/lolcommits/backends/git_info.rb
@@ -11,6 +11,10 @@ module Lolcommits
       File.directory?(File.join(path, '.git'))
     end
 
+    def self.local_name(path = '.')
+      File.basename(Git.open(path).dir.to_s)
+    end
+
     def initialize
       debug 'GitInfo: parsed the following values from commit:'
       debug "GitInfo: \t#{message}"

--- a/lib/lolcommits/backends/git_info.rb
+++ b/lib/lolcommits/backends/git_info.rb
@@ -7,7 +7,7 @@ module Lolcommits
 
     GIT_URL_REGEX = %r{.*[:]([\/\w\-]*).git}
 
-    def self.is_repo_root?(path='.')
+    def self.repo_root?(path = '.')
       File.directory?(File.join(path, '.git'))
     end
 

--- a/lib/lolcommits/backends/git_info.rb
+++ b/lib/lolcommits/backends/git_info.rb
@@ -8,7 +8,7 @@ module Lolcommits
     GIT_URL_REGEX = %r{.*[:]([\/\w\-]*).git}
 
     def self.is_repo_root?(path='.')
-      Dir.exists?(File.join(path, '.git'))
+      File.directory?(File.join(path, '.git'))
     end
 
     def initialize

--- a/lib/lolcommits/backends/installation_git.rb
+++ b/lib/lolcommits/backends/installation_git.rb
@@ -1,0 +1,126 @@
+# -*- encoding : utf-8 -*-
+module Lolcommits
+  #
+  # Methods to handle enabling and disabling of lolcommits
+  #
+  class InstallationGit
+    HOOK_PATH = File.join '.git', 'hooks', 'post-commit'
+    HOOK_DIR = File.join '.git', 'hooks'
+
+    #
+    # IF --ENABLE, DO ENABLE
+    #
+    def self.do_enable
+      unless File.directory?('.git')
+        fatal "You don't appear to be in the base directory of a git project."
+        exit 1
+      end
+
+      # its possible a hooks dir doesnt exist, so create it if so
+      Dir.mkdir(HOOK_DIR) unless File.directory?(HOOK_DIR)
+
+      # should add a shebang (or not) adding will rewrite hook file
+      add_shebang = false
+      if hook_file_exists?
+        # clear away any existing lolcommits hook
+        remove_existing_hook! if lolcommits_hook_exists?
+
+        # if file is empty we should add a shebang (and rewrite hook)
+        if File.read(HOOK_PATH).strip.empty?
+          add_shebang = true
+        elsif !good_shebang?
+          # look for good shebang in existing hook, abort if none found
+          warn "the existing hook (at #{HOOK_PATH}) doesn't start with a good shebang; like #!/bin/sh"
+          exit 1
+        end
+      else
+        add_shebang = true
+      end
+
+      File.open(HOOK_PATH, add_shebang ? 'w' : 'a') do |f|
+        f.write("#!/bin/sh\n") if add_shebang
+        f.write(hook_script)
+      end
+
+      FileUtils.chmod 0755, HOOK_PATH
+
+      info 'installed lolcommit hook to:'
+      info "  -> #{File.expand_path(HOOK_PATH)}"
+      info '(to remove later, you can use: lolcommits --disable)'
+      # we dont symlink, but rather install a small stub that calls the one from path
+      # that way, as gem version changes, script updates even if new file thus breaking symlink
+    end
+
+    #
+    # IF --DISABLE, DO DISABLE
+    #
+    def self.do_disable
+      if lolcommits_hook_exists?
+        remove_existing_hook!
+        info "uninstalled lolcommits hook (from #{HOOK_PATH})"
+      elsif File.exist?(HOOK_PATH)
+        info "couldn't find an lolcommits hook (at #{HOOK_PATH})"
+        if File.read(HOOK_PATH) =~ /lolcommit/
+          info "warning: an older-style lolcommit hook may still exist, edit #{HOOK_PATH} to remove it manually"
+        end
+      else
+        info "no post commit hook found (at #{HOOK_PATH}), so there is nothing to uninstall"
+      end
+    end
+
+    def self.hook_script
+      ruby_path     = Lolcommits::Platform.command_which('ruby', true)
+      imagick_path  = Lolcommits::Platform.command_which('identify', true)
+
+      if Lolcommits::Platform.platform_windows?
+        hook_export = "set path \"#{ruby_path};#{imagick_path};%PATH%\"\n"
+      else
+        locale_export = "export LANG=\"#{ENV['LANG']}\"\n"
+        hook_export   = "export PATH=\"#{ruby_path}:#{imagick_path}:$PATH\"\n"
+      end
+
+      capture_cmd   = 'lolcommits --capture'
+      capture_args  = " #{ARGV[1..-1].join(' ')}" if ARGV.length > 1
+
+      <<-EOS
+### lolcommits hook (begin) ###
+if [ ! -d "$GIT_DIR/rebase-merge" ]; then
+#{locale_export}#{hook_export}#{capture_cmd}#{capture_args}
+fi
+###  lolcommits hook (end)  ###
+EOS
+    end
+
+    # does a git hook exist at all?
+    def self.hook_file_exists?
+      File.exist?(HOOK_PATH)
+    end
+
+    # does a git hook exist with lolcommits commands?
+    def self.lolcommits_hook_exists?
+      hook_file_exists? &&
+        File.read(HOOK_PATH).to_s =~ /lolcommits.*\(begin\)(.*\n)*.*lolcommits.*\(end\)/
+    end
+
+    # does the git hook file have a good shebang?
+    def self.good_shebang?
+      File.read(HOOK_PATH).lines.first =~ %r{^\#\!\/bin\/.*sh}
+    end
+
+    def self.remove_existing_hook!
+      hook = File.read(HOOK_PATH)
+      out  = File.open(HOOK_PATH, 'w')
+      skip = false
+
+      hook.lines.each do |line|
+        skip = true if !skip && (line =~ /lolcommits.*\(begin\)/)
+
+        out << line unless skip
+
+        skip = false if skip && (line =~ /lolcommits.*\(end\)/)
+      end
+
+      out.close
+    end
+  end
+end

--- a/lib/lolcommits/backends/installation_git.rb
+++ b/lib/lolcommits/backends/installation_git.rb
@@ -43,12 +43,7 @@ module Lolcommits
       end
 
       FileUtils.chmod 0755, HOOK_PATH
-
-      info 'installed lolcommit hook to:'
-      info "  -> #{File.expand_path(HOOK_PATH)}"
-      info '(to remove later, you can use: lolcommits --disable)'
-      # we dont symlink, but rather install a small stub that calls the one from path
-      # that way, as gem version changes, script updates even if new file thus breaking symlink
+      HOOK_PATH
     end
 
     #

--- a/lib/lolcommits/backends/installation_mercurial.rb
+++ b/lib/lolcommits/backends/installation_mercurial.rb
@@ -1,0 +1,88 @@
+# -*- encoding : utf-8 -*-
+module Lolcommits
+  #
+  # Methods to handle enabling and disabling of lolcommits
+  #
+  class InstallationMercurial
+    HOOK_SECTION = 'hooks'
+    HOOK_OPERATIONS=['commit', 'record', 'crecord']
+
+    #
+    # IF --ENABLE, DO ENABLE
+    #
+    def self.do_enable
+      unless File.directory?('.hg')
+        fatal "You don't appear to be in the base directory of a mercurial project."
+        exit 1
+      end
+
+      if lolcommits_hook_exists?
+        # clear away any existing lolcommits hook
+        remove_existing_hook!
+      end
+
+      config = repository.config
+      HOOK_OPERATIONS.each do |op|
+        config.add_setting(HOOK_SECTION, "post-#{op}.lolcommits", hook_script)
+      end
+      config.path
+    end
+
+    #
+    # IF --DISABLE, DO DISABLE
+    #
+    def self.do_disable
+      config = repository.config
+      if lolcommits_hook_exists?
+        remove_existing_hook!
+        info "uninstalled lolcommits hook (from #{config.path})"
+      elsif config.exists?
+        info "couldn't find an lolcommits hook (at #{config.path})"
+      else
+        info "no post commit hook found (at #{config.path}), so there is nothing to uninstall"
+      end
+    end
+
+    def self.hook_script
+      ruby_path     = Lolcommits::Platform.command_which('ruby', true)
+      imagick_path  = Lolcommits::Platform.command_which('identify', true)
+
+      if Lolcommits::Platform.platform_windows?
+        # TODO
+        # hook_export = "set path \"#{ruby_path};#{imagick_path};%PATH%\"\n"
+      else
+        locale_export = "LANG=\"#{ENV['LANG']}\""
+        hook_export   = "PATH=\"#{ruby_path}:#{imagick_path}:$PATH\""
+      end
+
+      capture_cmd   = 'lolcommits --capture'
+      capture_args  = " #{ARGV[1..-1].join(' ')}" if ARGV.length > 1
+      return "#{locale_export} #{hook_export} #{capture_cmd} #{capture_args}"
+    end
+
+    def self.repository
+      Mercurial::Repository.open('.')
+    end
+
+    # does a mercurial hook exist with lolcommits commands?
+    def self.lolcommits_hook_exists?
+      config = repository.config
+      config.exists? && config.setting_exists?(HOOK_SECTION, 'post-commit.lolcommits')
+    end
+
+    # can we load the hgrc?
+    def self.valid_hgrc?
+      repository.config.exists?
+    end
+
+    def self.remove_existing_hook!
+      config = repository.config
+      HOOK_OPERATIONS.each do |op|
+        setting = "post-#{op}.lolcommits"
+        if config.setting_exists?(HOOK_SECTION, setting)
+          config.delete_setting!(HOOK_SECTION, setting)
+        end
+      end
+    end
+  end
+end

--- a/lib/lolcommits/backends/installation_mercurial.rb
+++ b/lib/lolcommits/backends/installation_mercurial.rb
@@ -4,8 +4,8 @@ module Lolcommits
   # Methods to handle enabling and disabling of lolcommits
   #
   class InstallationMercurial
-    HOOK_SECTION = 'hooks'
-    HOOK_OPERATIONS=['commit', 'record', 'crecord']
+    HOOK_SECTION = 'hooks'.freeze
+    HOOK_OPERATIONS = %w(commit record crecord).freeze
 
     #
     # IF --ENABLE, DO ENABLE
@@ -56,8 +56,8 @@ module Lolcommits
         capture_cmd = "#{locale_export} #{hook_export} #{capture_cmd}"
       end
 
-      capture_args  = "#{ARGV[1..-1].join(' ')}" if ARGV.length > 1
-      return "#{capture_cmd} #{capture_args}"
+      capture_args = ARGV[1..-1].join(' ') if ARGV.length > 1
+      "#{capture_cmd} #{capture_args}"
     end
 
     def self.repository

--- a/lib/lolcommits/backends/installation_mercurial.rb
+++ b/lib/lolcommits/backends/installation_mercurial.rb
@@ -56,7 +56,7 @@ module Lolcommits
         capture_cmd = "#{locale_export} #{hook_export} #{capture_cmd}"
       end
 
-      capture_args  = " #{ARGV[1..-1].join(' ')}" if ARGV.length > 1
+      capture_args  = "#{ARGV[1..-1].join(' ')}" if ARGV.length > 1
       return "#{capture_cmd} #{capture_args}"
     end
 

--- a/lib/lolcommits/backends/installation_mercurial.rb
+++ b/lib/lolcommits/backends/installation_mercurial.rb
@@ -46,18 +46,18 @@ module Lolcommits
     def self.hook_script
       ruby_path     = Lolcommits::Platform.command_which('ruby', true)
       imagick_path  = Lolcommits::Platform.command_which('identify', true)
+      capture_cmd   = 'lolcommits --capture'
 
       if Lolcommits::Platform.platform_windows?
-        # TODO
-        # hook_export = "set path \"#{ruby_path};#{imagick_path};%PATH%\"\n"
+        capture_cmd = "set path \"#{ruby_path};#{imagick_path};%PATH%\"&&#{capture_cmd}"
       else
         locale_export = "LANG=\"#{ENV['LANG']}\""
         hook_export   = "PATH=\"#{ruby_path}:#{imagick_path}:$PATH\""
+        capture_cmd = "#{locale_export} #{hook_export} #{capture_cmd}"
       end
 
-      capture_cmd   = 'lolcommits --capture'
       capture_args  = " #{ARGV[1..-1].join(' ')}" if ARGV.length > 1
-      return "#{locale_export} #{hook_export} #{capture_cmd} #{capture_args}"
+      return "#{capture_cmd} #{capture_args}"
     end
 
     def self.repository

--- a/lib/lolcommits/backends/mercurial_info.rb
+++ b/lib/lolcommits/backends/mercurial_info.rb
@@ -6,7 +6,7 @@ module Lolcommits
                   :author_name, :author_email, :branch
 
     def self.is_repo_root?(path='.')
-      Dir.exists?(File.join(path, '.hg'))
+      File.directory?(File.join(path, '.hg'))
     end
 
     def initialize

--- a/lib/lolcommits/backends/mercurial_info.rb
+++ b/lib/lolcommits/backends/mercurial_info.rb
@@ -57,7 +57,7 @@ module Lolcommits
     end
 
     def repo
-      @repo ||= repository.path # FIXME: ?
+      @repo ||= File.basename(File.dirname(repo_internal_path))
     end
 
     def author_name

--- a/lib/lolcommits/backends/mercurial_info.rb
+++ b/lib/lolcommits/backends/mercurial_info.rb
@@ -5,6 +5,10 @@ module Lolcommits
     attr_accessor :sha, :message, :repo_internal_path, :repo, :url,
                   :author_name, :author_email, :branch
 
+    def self.is_repo_root?(path='.')
+      Dir.exists?(File.join(path, '.hg'))
+    end
+
     def initialize
       # mercurial sets HG_RESULT for post- hooks
       if ENV.has_key?('HG_RESULT') && ENV['HG_RESULT'] != '0'

--- a/lib/lolcommits/backends/mercurial_info.rb
+++ b/lib/lolcommits/backends/mercurial_info.rb
@@ -49,7 +49,7 @@ module Lolcommits
     end
 
     def repo_internal_path
-      @repo_internal_path ||= File.dirname(repository.dothg_path)
+      @repo_internal_path ||= repository.dothg_path
     end
 
     def url

--- a/lib/lolcommits/backends/mercurial_info.rb
+++ b/lib/lolcommits/backends/mercurial_info.rb
@@ -5,13 +5,13 @@ module Lolcommits
     attr_accessor :sha, :message, :repo_internal_path, :repo, :url,
                   :author_name, :author_email, :branch
 
-    def self.is_repo_root?(path='.')
+    def self.repo_root?(path = '.')
       File.directory?(File.join(path, '.hg'))
     end
 
     def initialize
       # mercurial sets HG_RESULT for post- hooks
-      if ENV.has_key?('HG_RESULT') && ENV['HG_RESULT'] != '0'
+      if ENV.key?('HG_RESULT') && ENV['HG_RESULT'] != '0'
         debug 'Aborting lolcommits hook from failed operation'
         exit 1
       end

--- a/lib/lolcommits/backends/mercurial_info.rb
+++ b/lib/lolcommits/backends/mercurial_info.rb
@@ -9,6 +9,10 @@ module Lolcommits
       File.directory?(File.join(path, '.hg'))
     end
 
+    def self.local_name(path = '.')
+      File.basename(File.dirname(Mercurial::Repository.open(path).dothg_path))
+    end
+
     def initialize
       # mercurial sets HG_RESULT for post- hooks
       if ENV.key?('HG_RESULT') && ENV['HG_RESULT'] != '0'

--- a/lib/lolcommits/backends/mercurial_info.rb
+++ b/lib/lolcommits/backends/mercurial_info.rb
@@ -1,0 +1,73 @@
+# -*- encoding : utf-8 -*-
+module Lolcommits
+  class MercurialInfo < VCSInfo
+    include Methadone::CLILogging
+    attr_accessor :sha, :message, :repo_internal_path, :repo, :url,
+                  :author_name, :author_email, :branch
+
+    def initialize
+      # mercurial sets HG_RESULT for post- hooks
+      if ENV.has_key?('HG_RESULT') && ENV['HG_RESULT'] != '0'
+        debug 'Aborting lolcommits hook from failed operation'
+        exit 1
+      end
+
+      Mercurial.configure do |conf|
+        conf.hg_binary_path = 'hg'
+      end
+      debug 'MercurialInfo: parsed the following values from commit:'
+      debug "MercurialInfo: \t#{message}"
+      debug "MercurialInfo: \t#{sha}"
+      debug "MercurialInfo: \t#{repo_internal_path}"
+      debug "MercurialInfo: \t#{repo}"
+      debug "MercurialInfo: \t#{branch}"
+      debug "MercurialInfo: \t#{author_name}" if author_name
+      debug "MercurialInfo: \t#{author_email}" if author_email
+    end
+
+    def branch
+      @branch ||= last_commit.branch_name
+    end
+
+    def message
+      @message ||= begin
+        message = last_commit.message || ''
+        message.split("\n").first
+      end
+    end
+
+    def sha
+      @sha ||= last_commit.id[0..10]
+    end
+
+    def repo_internal_path
+      @repo_internal_path ||= File.dirname(repository.dothg_path)
+    end
+
+    def url
+      @url ||= repository.path
+    end
+
+    def repo
+      @repo ||= repository.path # FIXME: ?
+    end
+
+    def author_name
+      @author_name ||= last_commit.author
+    end
+
+    def author_email
+      @author_email ||= last_commit.author_email
+    end
+
+    private
+
+    def repository(path = '.')
+      @repository ||= Mercurial::Repository.open(path)
+    end
+
+    def last_commit
+      @commit ||= repository.commits.parent
+    end
+  end
+end

--- a/lib/lolcommits/cli/fatals.rb
+++ b/lib/lolcommits/cli/fatals.rb
@@ -66,26 +66,17 @@ module Lolcommits
       # Die with an informative error message in that case.
       def self.die_if_not_vcs_repo!
         debug 'Checking for valid vcs repo'
-        fatal_message = nil
-        # FIXME: should be extracted to VCSInfo class
-        begin
-          if GitInfo.is_repo_root?('.')
-            Git.open('.')
-          elsif MercurialInfo.is_repo_root?('.')
-            Mercurial::Repository.open('.')
-          else
-            fatal_message = 'Unknown VCS'
+        current = File.expand_path('.')
+        parent = File.dirname(current)
+        while current != parent
+          if VCSInfo.is_repo_root?(current)
+            return
           end
-        rescue ArgumentError
-          # ruby-git throws an argument error if path isnt for a valid git repo.
-          fatal_message = "Erm? Can't do that since we're not in a valid git repository!"
-        rescue RepositoryNotFound
-          fatal_message = 'Invalid mercurial repository'
+          current = parent
+          parent = File.dirname(current)
         end
-        if fatal_message
-          fatal fatal_message
-          exit 1
-        end
+        fatal 'Unknown VCS'
+        exit 1
       end
     end
   end

--- a/lib/lolcommits/cli/fatals.rb
+++ b/lib/lolcommits/cli/fatals.rb
@@ -64,14 +64,14 @@ module Lolcommits
 
       # If we are not in a git repo, we can't do git related things!
       # Die with an informative error message in that case.
-      def self.die_if_not_git_repo!
+      def self.die_if_not_vcs_repo!
         debug 'Checking for valid vcs repo'
         fatal_message = nil
         # FIXME: should be extracted to VCSInfo class
         begin
-          if Dir.exists?('.git')
+          if GitInfo.is_repo_root?('.')
             Git.open('.')
-          elsif Dir.exists?('.hg')
+          elsif MercurialInfo.is_repo_root?('.')
             Mercurial::Repository.open('.')
           else
             fatal_message = 'Unknown VCS'

--- a/lib/lolcommits/cli/fatals.rb
+++ b/lib/lolcommits/cli/fatals.rb
@@ -69,9 +69,7 @@ module Lolcommits
         current = File.expand_path('.')
         parent = File.dirname(current)
         while current != parent
-          if VCSInfo.is_repo_root?(current)
-            return
-          end
+          return if VCSInfo.repo_root?(current)
           current = parent
           parent = File.dirname(current)
         end

--- a/lib/lolcommits/cli/timelapse_gif.rb
+++ b/lib/lolcommits/cli/timelapse_gif.rb
@@ -15,7 +15,7 @@ module Lolcommits
       # Runs the history timeline animator task thingy
       # param args [String] the arg passed to the gif command on CLI (optional)
       def run(args = nil)
-        Fatals.die_if_not_git_repo!
+        Fatals.die_if_not_vcs_repo!
 
         case args
         when 'today'

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -23,8 +23,13 @@ module Lolcommits
 
     def loldir
       return @loldir if @loldir
-      basename ||= File.basename(Git.open('.').dir.to_s).sub(/^\./, 'dot')
-      basename.sub!(/ /, '-')
+      if Dir.exists?('.git')
+        basename ||= File.basename(Git.open('.').dir.to_s).sub(/^\./, 'dot')
+        basename.sub!(/ /, '-')
+      elsif Dir.exists?('.hg')
+        basename ||= File.basename(File.dirname(Mercurial::Repository.open('.').dothg_path)).sub(/^\./, 'dot')
+        basename.sub!(/ /, '-')
+      end
       @loldir = Configuration.loldir_for(basename)
     end
 

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -29,6 +29,8 @@ module Lolcommits
       elsif MercurialInfo.is_repo_root?('.')
         basename ||= File.basename(File.dirname(Mercurial::Repository.open('.').dothg_path)).sub(/^\./, 'dot')
         basename.sub!(/ /, '-')
+      else
+        basename ||= File.basename(Dir.getwd)
       end
       @loldir = Configuration.loldir_for(basename)
     end

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -23,10 +23,10 @@ module Lolcommits
 
     def loldir
       return @loldir if @loldir
-      if GitInfo.is_repo_root?('.')
+      if GitInfo.repo_root?('.')
         basename ||= File.basename(Git.open('.').dir.to_s).sub(/^\./, 'dot')
         basename.sub!(/ /, '-')
-      elsif MercurialInfo.is_repo_root?('.')
+      elsif MercurialInfo.repo_root?('.')
         basename ||= File.basename(File.dirname(Mercurial::Repository.open('.').dothg_path)).sub(/^\./, 'dot')
         basename.sub!(/ /, '-')
       else

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -23,10 +23,10 @@ module Lolcommits
 
     def loldir
       return @loldir if @loldir
-      if Dir.exists?('.git')
+      if GitInfo.is_repo_root?('.')
         basename ||= File.basename(Git.open('.').dir.to_s).sub(/^\./, 'dot')
         basename.sub!(/ /, '-')
-      elsif Dir.exists?('.hg')
+      elsif MercurialInfo.is_repo_root?('.')
         basename ||= File.basename(File.dirname(Mercurial::Repository.open('.').dothg_path)).sub(/^\./, 'dot')
         basename.sub!(/ /, '-')
       end

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -23,15 +23,13 @@ module Lolcommits
 
     def loldir
       return @loldir if @loldir
-      if GitInfo.repo_root?('.')
-        basename ||= File.basename(Git.open('.').dir.to_s).sub(/^\./, 'dot')
-        basename.sub!(/ /, '-')
-      elsif MercurialInfo.repo_root?('.')
-        basename ||= File.basename(File.dirname(Mercurial::Repository.open('.').dothg_path)).sub(/^\./, 'dot')
-        basename.sub!(/ /, '-')
-      else
-        basename ||= File.basename(Dir.getwd)
-      end
+      basename ||= if VCSInfo.repo_root?
+                     VCSInfo.local_name
+                   else
+                     File.basename(Dir.getwd)
+                   end
+      basename.sub!(/^\./, 'dot')
+      basename.sub!(/ /, '-')
       @loldir = Configuration.loldir_for(basename)
     end
 

--- a/lib/lolcommits/installation.rb
+++ b/lib/lolcommits/installation.rb
@@ -5,9 +5,9 @@ module Lolcommits
   #
   class Installation
     def self.backend
-      if GitInfo.repo_root?('.')
+      if GitInfo.repo_root?
         InstallationGit
-      elsif MercurialInfo.repo_root?('.')
+      elsif MercurialInfo.repo_root?
         InstallationMercurial
       else
         fatal "You don't appear to be in the base directory of a supported vcs project."

--- a/lib/lolcommits/installation.rb
+++ b/lib/lolcommits/installation.rb
@@ -4,123 +4,46 @@ module Lolcommits
   # Methods to handle enabling and disabling of lolcommits
   #
   class Installation
-    HOOK_PATH = File.join '.git', 'hooks', 'post-commit'
-    HOOK_DIR = File.join '.git', 'hooks'
+    @@backend = nil
 
     #
     # IF --ENABLE, DO ENABLE
     #
     def self.do_enable
-      unless File.directory?('.git')
-        fatal "You don't appear to be in the base directory of a git project."
-        exit 1
+      if File.directory?('.git')
+        InstallationGit.do_enable
+        @@backend = InstallationGit
       end
-
-      # its possible a hooks dir doesnt exist, so create it if so
-      Dir.mkdir(HOOK_DIR) unless File.directory?(HOOK_DIR)
-
-      # should add a shebang (or not) adding will rewrite hook file
-      add_shebang = false
-      if hook_file_exists?
-        # clear away any existing lolcommits hook
-        remove_existing_hook! if lolcommits_hook_exists?
-
-        # if file is empty we should add a shebang (and rewrite hook)
-        if File.read(HOOK_PATH).strip.empty?
-          add_shebang = true
-        elsif !good_shebang?
-          # look for good shebang in existing hook, abort if none found
-          warn "the existing hook (at #{HOOK_PATH}) doesn't start with a good shebang; like #!/bin/sh"
-          exit 1
-        end
-      else
-        add_shebang = true
-      end
-
-      File.open(HOOK_PATH, add_shebang ? 'w' : 'a') do |f|
-        f.write("#!/bin/sh\n") if add_shebang
-        f.write(hook_script)
-      end
-
-      FileUtils.chmod 0755, HOOK_PATH
-
-      info 'installed lolcommit hook to:'
-      info "  -> #{File.expand_path(HOOK_PATH)}"
-      info '(to remove later, you can use: lolcommits --disable)'
-      # we dont symlink, but rather install a small stub that calls the one from path
-      # that way, as gem version changes, script updates even if new file thus breaking symlink
     end
 
     #
     # IF --DISABLE, DO DISABLE
     #
     def self.do_disable
-      if lolcommits_hook_exists?
-        remove_existing_hook!
-        info "uninstalled lolcommits hook (from #{HOOK_PATH})"
-      elsif File.exist?(HOOK_PATH)
-        info "couldn't find an lolcommits hook (at #{HOOK_PATH})"
-        if File.read(HOOK_PATH) =~ /lolcommit/
-          info "warning: an older-style lolcommit hook may still exist, edit #{HOOK_PATH} to remove it manually"
-        end
-      else
-        info "no post commit hook found (at #{HOOK_PATH}), so there is nothing to uninstall"
-      end
+      @@backend.do_disable
     end
 
     def self.hook_script
-      ruby_path     = Lolcommits::Platform.command_which('ruby', true)
-      imagick_path  = Lolcommits::Platform.command_which('identify', true)
-
-      if Lolcommits::Platform.platform_windows?
-        hook_export = "set path \"#{ruby_path};#{imagick_path};%PATH%\"\n"
-      else
-        locale_export = "export LANG=\"#{ENV['LANG']}\"\n"
-        hook_export   = "export PATH=\"#{ruby_path}:#{imagick_path}:$PATH\"\n"
-      end
-
-      capture_cmd   = 'lolcommits --capture'
-      capture_args  = " #{ARGV[1..-1].join(' ')}" if ARGV.length > 1
-
-      <<-EOS
-### lolcommits hook (begin) ###
-if [ ! -d "$GIT_DIR/rebase-merge" ]; then
-#{locale_export}#{hook_export}#{capture_cmd}#{capture_args}
-fi
-###  lolcommits hook (end)  ###
-EOS
+      @@backend.hook_script
     end
 
-    # does a git hook exist at all?
+    # does a hook exist at all?
     def self.hook_file_exists?
-      File.exist?(HOOK_PATH)
+      @@backend.hook_file_exists?
     end
 
-    # does a git hook exist with lolcommits commands?
+    # does a hook exist with lolcommits commands?
     def self.lolcommits_hook_exists?
-      hook_file_exists? &&
-        File.read(HOOK_PATH).to_s =~ /lolcommits.*\(begin\)(.*\n)*.*lolcommits.*\(end\)/
+      @@backend.lolcommits_hook_exists?
     end
 
-    # does the git hook file have a good shebang?
+    # does the hook file have a good shebang?
     def self.good_shebang?
-      File.read(HOOK_PATH).lines.first =~ %r{^\#\!\/bin\/.*sh}
+      @@backend.good_shebang?
     end
 
     def self.remove_existing_hook!
-      hook = File.read(HOOK_PATH)
-      out  = File.open(HOOK_PATH, 'w')
-      skip = false
-
-      hook.lines.each do |line|
-        skip = true if !skip && (line =~ /lolcommits.*\(begin\)/)
-
-        out << line unless skip
-
-        skip = false if skip && (line =~ /lolcommits.*\(end\)/)
-      end
-
-      out.close
+      @@backend.remove_existing_hook!
     end
   end
 end

--- a/lib/lolcommits/installation.rb
+++ b/lib/lolcommits/installation.rb
@@ -4,46 +4,32 @@ module Lolcommits
   # Methods to handle enabling and disabling of lolcommits
   #
   class Installation
-    @@backend = nil
+    def self.backend
+      if File.directory?('.git')
+        InstallationGit
+      elsif File.directory?('.hg')
+        InstallationMercurial
+      end
+    end
 
     #
     # IF --ENABLE, DO ENABLE
     #
     def self.do_enable
-      if File.directory?('.git')
-        InstallationGit.do_enable
-        @@backend = InstallationGit
-      end
+      path = backend.do_enable
+
+      info 'installed lolcommit hook to:'
+      info "  -> #{File.expand_path(path)}"
+      info '(to remove later, you can use: lolcommits --disable)'
+      # we dont symlink, but rather install a small stub that calls the one from path
+      # that way, as gem version changes, script updates even if new file thus breaking symlink
     end
 
     #
     # IF --DISABLE, DO DISABLE
     #
     def self.do_disable
-      @@backend.do_disable
-    end
-
-    def self.hook_script
-      @@backend.hook_script
-    end
-
-    # does a hook exist at all?
-    def self.hook_file_exists?
-      @@backend.hook_file_exists?
-    end
-
-    # does a hook exist with lolcommits commands?
-    def self.lolcommits_hook_exists?
-      @@backend.lolcommits_hook_exists?
-    end
-
-    # does the hook file have a good shebang?
-    def self.good_shebang?
-      @@backend.good_shebang?
-    end
-
-    def self.remove_existing_hook!
-      @@backend.remove_existing_hook!
+      backend.do_disable
     end
   end
 end

--- a/lib/lolcommits/installation.rb
+++ b/lib/lolcommits/installation.rb
@@ -5,10 +5,13 @@ module Lolcommits
   #
   class Installation
     def self.backend
-      if File.directory?('.git')
+      if GitInfo.is_repo_root?('.')
         InstallationGit
-      elsif File.directory?('.hg')
+      elsif MercurialInfo.is_repo_root?('.')
         InstallationMercurial
+      else
+        fatal "You don't appear to be in the base directory of a supported vcs project."
+        exit 1
       end
     end
 

--- a/lib/lolcommits/installation.rb
+++ b/lib/lolcommits/installation.rb
@@ -5,9 +5,9 @@ module Lolcommits
   #
   class Installation
     def self.backend
-      if GitInfo.is_repo_root?('.')
+      if GitInfo.repo_root?('.')
         InstallationGit
-      elsif MercurialInfo.is_repo_root?('.')
+      elsif MercurialInfo.repo_root?('.')
         InstallationMercurial
       else
         fatal "You don't appear to be in the base directory of a supported vcs project."

--- a/lib/lolcommits/plugins/lol_protonet.rb
+++ b/lib/lolcommits/plugins/lol_protonet.rb
@@ -27,7 +27,7 @@ module Lolcommits
     end
 
     def message
-      "commited some #{random_adjective} #{random_object} to #{runner.git_info.repo}@#{runner.sha} (#{runner.git_info.branch}) "
+      "commited some #{random_adjective} #{random_object} to #{runner.vcs_info.repo}@#{runner.sha} (#{runner.vcs_info.branch}) "
     end
 
     def random_object

--- a/lib/lolcommits/plugins/lol_slack.rb
+++ b/lib/lolcommits/plugins/lol_slack.rb
@@ -52,7 +52,7 @@ module Lolcommits
           :token    => configuration['access_token'],
           :filetype => 'jpg',
           :filename => runner.sha,
-          :title    => runner.message + "[#{runner.git_info.repo}]",
+          :title    => runner.message + "[#{runner.vcs_info.repo}]",
           :channels => configuration['channels'])
 
         debug response

--- a/lib/lolcommits/plugins/lolsrv.rb
+++ b/lib/lolcommits/plugins/lolsrv.rb
@@ -40,8 +40,8 @@ module Lolcommits
     def upload(file, sha)
       RestClient.post(configuration['server'] + '/uplol',
                       :lol  => File.new(file),
-                      :url  => runner.git_info.url + sha,
-                      :repo => runner.git_info.repo,
+                      :url  => runner.vcs_info.url + sha,
+                      :repo => runner.vcs_info.repo,
                       :date => File.ctime(file),
                       :sha  => sha)
     rescue => e

--- a/lib/lolcommits/plugins/uploldz.rb
+++ b/lib/lolcommits/plugins/uploldz.rb
@@ -21,7 +21,7 @@ module Lolcommits
     def run_postcapture
       return unless valid_configuration?
 
-      if runner.git_info.repo.empty?
+      if runner.vcs_info.repo.empty?
         puts 'Repo is empty, skipping upload'
       else
         debug "Posting capture to #{configuration['endpoint']}"
@@ -29,9 +29,9 @@ module Lolcommits
                         {
                           :file         => File.new(runner.main_image),
                           :message      => runner.message,
-                          :repo         => runner.git_info.repo,
-                          :author_name  => runner.git_info.author_name,
-                          :author_email => runner.git_info.author_email,
+                          :repo         => runner.vcs_info.repo,
+                          :author_name  => runner.vcs_info.author_name,
+                          :author_email => runner.vcs_info.author_email,
                           :sha          => runner.sha,
                           :key          => configuration['optional_key']
                         },

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -15,9 +15,9 @@ module Lolcommits
       end
 
       return unless sha.nil? || message.nil?
-      if GitInfo.repo_root?('.')
+      if GitInfo.repo_root?
         self.vcs_info = GitInfo.new
-      elsif MercurialInfo.repo_root?('.')
+      elsif MercurialInfo.repo_root?
         self.vcs_info = MercurialInfo.new
       else
         raise('Unknown VCS')

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -15,9 +15,9 @@ module Lolcommits
       end
 
       return unless sha.nil? || message.nil?
-      if Dir.exists?('.git')
+      if GitInfo.is_repo_root?('.')
         self.vcs_info = GitInfo.new
-      elsif Dir.exists?('.hg')
+      elsif MercurialInfo.is_repo_root?('.')
         self.vcs_info = MercurialInfo.new
       else
         raise('Unknown VCS')

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -4,7 +4,7 @@ require 'lolcommits/platform'
 module Lolcommits
   class Runner
     attr_accessor :capture_delay, :capture_stealth, :capture_device, :message,
-                  :sha, :snapshot_loc, :main_image, :config, :git_info,
+                  :sha, :snapshot_loc, :main_image, :config, :vcs_info,
                   :capture_animate
 
     include Methadone::CLILogging
@@ -15,9 +15,16 @@ module Lolcommits
       end
 
       return unless sha.nil? || message.nil?
-      self.git_info = GitInfo.new
-      self.sha      = git_info.sha if sha.nil?
-      self.message  = git_info.message if message.nil?
+      if Dir.exists?('.git')
+        self.vcs_info = GitInfo.new
+      elsif Dir.exists?('.hg')
+        self.vcs_info = MercurialInfo.new
+      else
+        raise('Unknown VCS')
+      end
+
+      self.sha      = vcs_info.sha if sha.nil?
+      self.message  = vcs_info.message if message.nil?
     end
 
     # wrap run to handle things that should happen before and after

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -15,9 +15,9 @@ module Lolcommits
       end
 
       return unless sha.nil? || message.nil?
-      if GitInfo.is_repo_root?('.')
+      if GitInfo.repo_root?('.')
         self.vcs_info = GitInfo.new
-      elsif MercurialInfo.is_repo_root?('.')
+      elsif MercurialInfo.repo_root?('.')
         self.vcs_info = MercurialInfo.new
       else
         raise('Unknown VCS')

--- a/lib/lolcommits/vcs_info.rb
+++ b/lib/lolcommits/vcs_info.rb
@@ -1,0 +1,45 @@
+# -*- encoding : utf-8 -*-
+module Lolcommits
+  # base class ala plugin.rb
+  class VCSInfo
+    include Methadone::CLILogging
+    attr_accessor :sha, :message, :repo_internal_path, :repo, :url,
+                  :author_name, :author_email, :branch
+
+    def initialize
+      puts 'Base VCS, no implementation'
+    end
+
+    def branch
+      puts 'Base VCS, no implementation'
+    end
+
+    def message
+      puts 'Base VCS, no implementation'
+    end
+
+    def sha
+      puts 'Base VCS, no implementation'
+    end
+
+    def repo_internal_path
+      puts 'Base VCS, no implementation'
+    end
+
+    def url
+      puts 'Base VCS, no implementation'
+    end
+
+    def repo
+      puts 'Base VCS, no implementation'
+    end
+
+    def author_name
+      puts 'Base VCS, no implementation'
+    end
+
+    def author_email
+      puts 'Base VCS, no implementation'
+    end
+  end
+end

--- a/lib/lolcommits/vcs_info.rb
+++ b/lib/lolcommits/vcs_info.rb
@@ -14,6 +14,16 @@ module Lolcommits
       raise NotImplementedError, "#{self.class.name} is a base class; implement '#{method}' in a subclass", caller
     end
 
+    def self.local_name(path = '.')
+      if GitInfo.repo_root?(path)
+        GitInfo.local_name(path)
+      elsif MercurialInfo.repo_root?(path)
+        MercurialInfo.local_name(path)
+      else
+        raise "'#{File.expand_path(path)}' is not the root of a supported VCS"
+      end
+    end
+
     def initialize
       base_message(__method__)
     end

--- a/lib/lolcommits/vcs_info.rb
+++ b/lib/lolcommits/vcs_info.rb
@@ -6,6 +6,10 @@ module Lolcommits
     attr_accessor :sha, :message, :repo_internal_path, :repo, :url,
                   :author_name, :author_email, :branch
 
+    def self.is_repo_root?(path='.')
+      GitInfo.is_repo_root?(path) || MercurialInfo.is_repo_root?(path)
+    end
+
     def initialize
       puts 'Base VCS, no implementation'
     end

--- a/lib/lolcommits/vcs_info.rb
+++ b/lib/lolcommits/vcs_info.rb
@@ -10,40 +10,44 @@ module Lolcommits
       GitInfo.repo_root?(path) || MercurialInfo.repo_root?(path)
     end
 
+    def self.base_message(method)
+      raise NotImplementedError, "#{self.class.name} is a base class; implement '#{method}' in a subclass", caller
+    end
+
     def initialize
-      puts 'Base VCS, no implementation'
+      base_message(__method__)
     end
 
     def branch
-      puts 'Base VCS, no implementation'
+      base_message(__method__)
     end
 
     def message
-      puts 'Base VCS, no implementation'
+      base_message(__method__)
     end
 
     def sha
-      puts 'Base VCS, no implementation'
+      base_message(__method__)
     end
 
     def repo_internal_path
-      puts 'Base VCS, no implementation'
+      base_message(__method__)
     end
 
     def url
-      puts 'Base VCS, no implementation'
+      base_message(__method__)
     end
 
     def repo
-      puts 'Base VCS, no implementation'
+      base_message(__method__)
     end
 
     def author_name
-      puts 'Base VCS, no implementation'
+      base_message(__method__)
     end
 
     def author_email
-      puts 'Base VCS, no implementation'
+      base_message(__method__)
     end
   end
 end

--- a/lib/lolcommits/vcs_info.rb
+++ b/lib/lolcommits/vcs_info.rb
@@ -6,8 +6,8 @@ module Lolcommits
     attr_accessor :sha, :message, :repo_internal_path, :repo, :url,
                   :author_name, :author_email, :branch
 
-    def self.is_repo_root?(path='.')
-      GitInfo.is_repo_root?(path) || MercurialInfo.is_repo_root?(path)
+    def self.repo_root?(path = '.')
+      GitInfo.repo_root?(path) || MercurialInfo.repo_root?(path)
     end
 
     def initialize

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('launchy', '~> 2.4.3')
   s.add_runtime_dependency('methadone', '~> 1.8.0')
   s.add_runtime_dependency('open4', '~> 1.3.4')
+  s.add_runtime_dependency('mercurial-ruby', '~> 0')
 
   # plugin gems
   s.add_runtime_dependency('twitter', '~> 5.13.0')       # twitter


### PR DESCRIPTION
Initial pass at mercurial support for lolcommits.
Most of the code was already nicely abstracted (yay!), so there's not too much refactoring.
I've verified that I didn't regress any tests, and added mercurial variants of ones that interact with the vcs.
I tried to minimize unnecessary code change while still implementing stuff in a nice way, but I'm totally willing to do more cleanup/refactor/etc. if you have a preference.

![5c3139cec49](https://cloud.githubusercontent.com/assets/142250/14244533/e310e5de-fa5b-11e5-9a75-4b693aa17e1a.jpg)
