### PR TITLE
Mercurial fixes for Windows

### DIFF
--- a/lib/core_ext/mercurial-ruby/command.rb
+++ b/lib/core_ext/mercurial-ruby/command.rb
@@ -1,0 +1,29 @@
+# need to use popen3 on windows - popen4 always eventually calls fork
+module Mercurial
+  class Command
+    private
+
+    def execution_proc
+      proc do
+        debug(command)
+        result = ''
+        error = ''
+        status = nil
+        Open3.popen3(command) do |_stdin, stdout, stderr, wait_thread|
+          Timeout.timeout(timeout) do
+            while (tmp = stdout.read(102_400))
+              result += tmp
+            end
+          end
+
+          while (tmp = stderr.read(1024))
+            error += tmp
+          end
+          status = wait_thread.value
+        end
+        raise_error_if_needed(status, error)
+        result
+      end
+    end
+  end
+end

--- a/lib/core_ext/mercurial-ruby/shell.rb
+++ b/lib/core_ext/mercurial-ruby/shell.rb
@@ -1,0 +1,16 @@
+# windows command line doesn't like single quotes
+module Mercurial
+  class Shell
+    def self.interpolate_arguments(cmd_with_args)
+      cmd_with_args.shift.tap do |cmd|
+        cmd.gsub!(/\?/) do
+          if Lolcommits::Platform.platform_windows?
+            "\"#{cmd_with_args.shift}\""
+          else
+            cmd_with_args.shift.to_s.enclose_in_single_quotes
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -11,6 +11,8 @@ require 'open3'
 require 'methadone'
 require 'date'
 require 'mercurial-ruby'
+require 'core_ext/mercurial-ruby/command'
+require 'core_ext/mercurial-ruby/shell'
 
 require 'lolcommits/version'
 require 'lolcommits/configuration'

--- a/lib/lolcommits/backends/installation_mercurial.rb
+++ b/lib/lolcommits/backends/installation_mercurial.rb
@@ -49,7 +49,7 @@ module Lolcommits
       capture_cmd   = 'lolcommits --capture'
 
       if Lolcommits::Platform.platform_windows?
-        capture_cmd = "set path \"#{ruby_path};#{imagick_path};%PATH%\"&&#{capture_cmd}"
+        capture_cmd = "set path=#{ruby_path};#{imagick_path};%PATH%&&#{capture_cmd}"
       else
         locale_export = "LANG=\"#{ENV['LANG']}\""
         hook_export   = "PATH=\"#{ruby_path}:#{imagick_path}:$PATH\""


### PR DESCRIPTION
I discovered some issues with my windows users:

- mercurial-ruby unnecessarily uses popen4, which ultimately calls fork, for all command execution
- mercurial-ruby wants to pass filename arguments with single quotes (which windows hates)
- I was setting the PATH envvar incorrectly for a single-line set+execute on windows