### PR TITLE
Add south gravity, overlays & uppercasing to loltext

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 127
+  Max: 150
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -121,17 +121,26 @@ Feature: Basic UI functionality
       Then I type "loltext"
       And I wait for output to contain "enabled:"
       Then I type "true"
+      And I wait for output to contain "global text:"
+      And I wait for output to contain "overlay"
+      Then I type "true"
+      And I wait for output to contain "overlay colors"
+      Then I type "#2884ae,#7e231f"
+      And I wait for output to contain "message text:"
       And I wait for output to contain "color"
       Then I type "red"
       And I wait for output to contain "font"
       Then I type "my-font.ttf"
       And I wait for output to contain "position"
-      Then I type "SouthEast"
+      Then I type "SE"
       And I wait for output to contain "size"
       Then I type "32"
       And I wait for output to contain "stroke color"
       Then I type "white"
+      And I wait for output to contain "uppercase"
+      Then I type "true"
       And I wait for output to contain "sha text"
+      Then I type ""
       Then I type ""
       Then I type ""
       Then I type ""
@@ -142,11 +151,19 @@ Feature: Basic UI functionality
       And a file named "~/.lolcommits/config-test/config.yml" should exist
     When I successfully run `lolcommits --show-config`
     Then the output should match /enabled: true/
+    And the output should match /:overlay: true/
+    And the output should match:
+    """
+        :overlay_colors:
+        - "#2884ae"
+        - "#7e231f"
+    """
     And the output should match /:font: my-font\.ttf/
     And the output should match /:size: 32/
-    And the output should match /:position: SouthEast/
+    And the output should match /:position: S/
     And the output should match /:color: red/
     And the output should match /:stroke_color: white/
+    And the output should match /:uppercase: true/
 
   Scenario: Configuring loltext plugin in test mode affects test loldir not repo loldir
     Given I am in a git repo named "testmode-config-test"

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -152,12 +152,7 @@ Feature: Basic UI functionality
     When I successfully run `lolcommits --show-config`
     Then the output should match /enabled: true/
     And the output should match /:overlay: true/
-    And the output should match:
-    """
-        :overlay_colors:
-        - .*#2884ae.*
-        - .*#7e231f.*
-    """
+    And the output should match /:overlay_colors:.*\n.*['"]#2884ae['"].*\n.*['"]#7e231f['"].*\n/
     And the output should match /:font: my-font\.ttf/
     And the output should match /:size: 32/
     And the output should match /:position: S/

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -155,8 +155,8 @@ Feature: Basic UI functionality
     And the output should match:
     """
         :overlay_colors:
-        - ['|"]#2884ae['|"]
-        - ['|"]#7e231f['|"]
+        - .*#2884ae.*
+        - .*#7e231f.*
     """
     And the output should match /:font: my-font\.ttf/
     And the output should match /:size: 32/

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -155,8 +155,8 @@ Feature: Basic UI functionality
     And the output should match:
     """
         :overlay_colors:
-        - "#2884ae"
-        - "#7e231f"
+        - ['|"]#2884ae['|"]
+        - ['|"]#7e231f['|"]
     """
     And the output should match /:font: my-font\.ttf/
     And the output should match /:size: 32/

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -15,7 +15,7 @@ module Lolcommits
     def run_postcapture
       debug 'Annotating image via MiniMagick'
       image = MiniMagick::Image.open(runner.main_image)
-      if (config_option(:global, :overlay))
+      if config_option(:global, :overlay)
         image.combine_options do |c|
           c.fill config_option(:global, :overlay_colors).sample
           c.colorize 50
@@ -33,12 +33,12 @@ module Lolcommits
 
       transformed_position = position_transform(config_option(type, :position))
       annotate_location = '0'
-      if (transformed_position == "South")
+      if transformed_position == 'South'
         font_size = config_option(type, :position)
         annotate_location = '+0+20' # Move South gravity off the edge of the image.
       end
 
-      if (config_option(type, :uppercase))
+      if config_option(type, :uppercase)
         string = string.upcase
       end
 
@@ -84,7 +84,7 @@ module Lolcommits
       defaults.keys.sort_by(&:to_s).reduce({}) do |acc, opt|
         print "  #{opt.to_s.tr('_', ' ')} (#{defaults[opt]}): "
         val = parse_user_input(STDIN.gets.strip)
-        if (opt == :overlay_colors)
+        if opt == :overlay_colors
           val = val.split(',')
         end
         acc.merge(opt => val)

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -41,12 +41,12 @@ module Lolcommits
       string.upcase! if config_option(type, :uppercase)
 
       image.combine_options do |c|
-        c.strokewidth '2'
-        c.interline_spacing '-9'
+        c.strokewidth runner.animate? ? '1' : '2'
+        c.interline_spacing -(config_option(type, :size)/5)
         c.stroke config_option(type, :stroke_color)
         c.fill config_option(type, :color)
         c.gravity transformed_position
-        c.pointsize runner.animate? ? 24 : config_option(type, :size)
+        c.pointsize runner.animate? ? (config_option(type, :size)/2) : config_option(type, :size)
         c.font config_option(type, :font)
         c.annotate annotate_location, string
       end
@@ -82,7 +82,7 @@ module Lolcommits
       defaults.keys.sort_by(&:to_s).reduce({}) do |acc, opt|
         print "  #{opt.to_s.tr('_', ' ')} (#{defaults[opt]}): "
         val = parse_user_input(STDIN.gets.strip)
-        val = val.split(',') if opt == :overlay_colors
+        val = val.split(',') if opt == :overlay_colors && !val.nil?
         acc.merge(opt => val)
       end
     end

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -37,9 +37,7 @@ module Lolcommits
         annotate_location = '+0+20' # Move South gravity off the edge of the image.
       end
 
-      if config_option(type, :uppercase)
-        string = string.upcase
-      end
+      string.upcase! if config_option(type, :uppercase)
 
       image.combine_options do |c|
         c.strokewidth '2'
@@ -83,9 +81,7 @@ module Lolcommits
       defaults.keys.sort_by(&:to_s).reduce({}) do |acc, opt|
         print "  #{opt.to_s.tr('_', ' ')} (#{defaults[opt]}): "
         val = parse_user_input(STDIN.gets.strip)
-        if opt == :overlay_colors
-          val = val.split(',')
-        end
+        val = val.split(',') if opt == :overlay_colors
         acc.merge(opt => val)
       end
     end

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -15,9 +15,9 @@ module Lolcommits
     def run_postcapture
       debug 'Annotating image via MiniMagick'
       image = MiniMagick::Image.open(runner.main_image)
-      if(config_option(:global, :overlay))
+      if (config_option(:global, :overlay))
         image.combine_options do |c|
-          c.fill config_option(:global,:overlay_colors).sample
+          c.fill config_option(:global, :overlay_colors).sample
           c.colorize 50
         end
       end
@@ -33,12 +33,12 @@ module Lolcommits
 
       transformed_position = position_transform(config_option(type, :position))
       annotate_location = '0'
-      if(transformed_position == "South")
+      if (transformed_position == "South")
         font_size = config_option(type, :position)
         annotate_location = '+0+20' # Move South gravity off the edge of the image.
       end
 
-      if(config_option(type, :uppercase))
+      if (config_option(type, :uppercase))
         string = string.upcase
       end
 
@@ -84,8 +84,8 @@ module Lolcommits
       defaults.keys.sort_by(&:to_s).reduce({}) do |acc, opt|
         print "  #{opt.to_s.tr('_', ' ')} (#{defaults[opt]}): "
         val = parse_user_input(STDIN.gets.strip)
-        if(opt == :overlay_colors)
-          val=val.split(",")
+        if (opt == :overlay_colors)
+          val = val.split(',')
         end
         acc.merge(opt => val)
       end
@@ -96,9 +96,9 @@ module Lolcommits
         :global => {
           :overlay => false,
           :overlay_colors => [
-            "#2e4970", "#674685", "#ca242f", "#1e7882", "#2884ae", "#4ba000",
-            "#187296", "#7e231f", "#017d9f", "#e52d7b", "#0f5eaa", "#e40087",
-            "#5566ac", "#ed8833", "#f8991c", "#408c93", "#ba9109"
+            '#2e4970', '#674685', '#ca242f', '#1e7882', '#2884ae', '#4ba000',
+            '#187296', '#7e231f', '#017d9f', '#e52d7b', '#0f5eaa', '#e40087',
+            '#5566ac', '#ed8833', '#f8991c', '#408c93', '#ba9109'
           ]
         },
         :message => {

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -41,11 +41,11 @@ module Lolcommits
 
       image.combine_options do |c|
         c.strokewidth runner.animate? ? '1' : '2'
-        c.interline_spacing -(config_option(type, :size)/5)
+        c.interline_spacing (-(config_option(type, :size) / 5))
         c.stroke config_option(type, :stroke_color)
         c.fill config_option(type, :color)
         c.gravity transformed_position
-        c.pointsize runner.animate? ? (config_option(type, :size)/2) : config_option(type, :size)
+        c.pointsize runner.animate? ? (config_option(type, :size) / 2) : config_option(type, :size)
         c.font config_option(type, :font)
         c.annotate annotate_location, string
       end

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -1,5 +1,6 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
+  # rubocop:disable ClassLength
   class Loltext < Plugin
     DEFAULT_FONT_PATH = File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'fonts', 'Impact.ttf')
 

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -1,6 +1,5 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
-  # rubocop:disable ClassLength
   class Loltext < Plugin
     DEFAULT_FONT_PATH = File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'fonts', 'Impact.ttf')
 

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -84,6 +84,9 @@ module Lolcommits
       defaults.keys.sort_by(&:to_s).reduce({}) do |acc, opt|
         print "  #{opt.to_s.tr('_', ' ')} (#{defaults[opt]}): "
         val = parse_user_input(STDIN.gets.strip)
+        if(opt == :overlay_colors)
+          val=val.split(",")
+        end
         acc.merge(opt => val)
       end
     end

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -41,7 +41,7 @@ module Lolcommits
 
       image.combine_options do |c|
         c.strokewidth runner.animate? ? '1' : '2'
-        c.interline_spacing (-(config_option(type, :size) / 5))
+        c.interline_spacing(-(config_option(type, :size) / 5))
         c.stroke config_option(type, :stroke_color)
         c.fill config_option(type, :color)
         c.gravity transformed_position

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -34,7 +34,6 @@ module Lolcommits
       transformed_position = position_transform(config_option(type, :position))
       annotate_location = '0'
       if transformed_position == 'South'
-        font_size = config_option(type, :position)
         annotate_location = '+0+20' # Move South gravity off the edge of the image.
       end
 


### PR DESCRIPTION

![f9dec2cb4ec](https://cloud.githubusercontent.com/assets/382760/15212562/0f8bbe64-1874-11e6-93d8-07b7f82fd220.jpg)

![948b37a4233](https://cloud.githubusercontent.com/assets/382760/15212766/43ec99ac-1875-11e6-96b5-593f3931b053.jpg)

Allows us to get to some real nice looking configurations. 

This idea and code is adapted from @levibuzolic's fork that contains [hipstertext](https://github.com/levibuzolic/lolcommits/blob/master/lib/lolcommits/plugins/hipstertext.rb)

The config for these image was this:
```
loltext:
  enabled: true
  :global:
    :overlay: true
    :overlay_colors:
  :message:
    :color:
    :font: "/Users/ruxton/Library/Fonts/Raleway-Light.ttf"
    :position: C
    :size: 30
    :stroke_color: none
    :uppercase: true
  :sha:
    :color:
    :font: "/Users/ruxton/Library/Fonts/Raleway-Light.ttf"
    :position: S
    :size: 20
    :stroke_color: none
    :uppercase: false
```