### PR TITLE
Show error when running with --config option in non git repo

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -108,6 +108,7 @@ def do_capture
 end
 
 def do_configure
+  Fatals.die_if_not_vcs_repo!
   $stdout.sync = true
   configuration.do_configure! Choice.choices[:plugin]
 end

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -197,7 +197,7 @@ Feature: Basic UI functionality
     When I run `lolcommits --last`
     Then the output should not contain:
       """
-      Unknown VCS
+      You don't appear to be in a directory of a supported vcs project.
       """
     And the exit status should be 0
 
@@ -207,7 +207,17 @@ Feature: Basic UI functionality
     When I run `lolcommits --last`
     Then the output should contain:
       """
-      Unknown VCS
+      You don't appear to be in a directory of a supported vcs project.
+      """
+    And the exit status should be 1
+
+  @in-tempdir
+  Scenario: Configuring loltext plugin if not in a lolrepo
+    Given I am in a directory named "gitsuxcvs4eva"
+    When I run `lolcommits --config`
+    Then the output should contain:
+      """
+      You don't appear to be in a directory of a supported vcs project.
       """
     And the exit status should be 1
 
@@ -235,7 +245,7 @@ Feature: Basic UI functionality
     When I run `lolcommits --browse`
     Then the output should not contain:
       """
-      Unknown VCS
+      You don't appear to be in a directory of a supported vcs project.
       """
     And the exit status should be 0
 
@@ -245,7 +255,7 @@ Feature: Basic UI functionality
     When I run `lolcommits --browse`
     Then the output should contain:
       """
-      Unknown VCS
+      You don't appear to be in a directory of a supported vcs project.
       """
     And the exit status should be 1
 
@@ -359,7 +369,7 @@ Feature: Basic UI functionality
     When I run `lolcommits --last`
     Then the output should not contain:
       """
-      Unknown VCS
+      You don't appear to be in a directory of a supported vcs project.
       """
     And the exit status should be 0
 
@@ -377,7 +387,7 @@ Feature: Basic UI functionality
     When I run `lolcommits --browse`
     Then the output should not contain:
       """
-      Unknown VCS
+      You don't appear to be in a directory of a supported vcs project.
       """
     And the exit status should be 0
 

--- a/lib/lolcommits/cli/fatals.rb
+++ b/lib/lolcommits/cli/fatals.rb
@@ -73,7 +73,7 @@ module Lolcommits
           current = parent
           parent = File.dirname(current)
         end
-        fatal 'Unknown VCS'
+        fatal "You don't appear to be in a directory of a supported vcs project."
         exit 1
       end
     end


### PR DESCRIPTION
Don't allow to `--config` unless within a known VCS repository path, instead show warning and exit 1.

* checks you are in the base (or a subdirectory) of a git repo
* uses our existing code for checking
* change message 'Unknown VCS' to 'You don't appear to be in a directory of a supported vcs project.'
* closes issue #307