### PR TITLE
Remove unneeded binaries

### DIFF
--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.executables   = 'lolcommits'
   s.require_paths = ['lib']
 
   # non-gem dependencies


### PR DESCRIPTION
There's no need to install a 'console' binary when deploying to Rubygems.org since 'console' is only used for development