### PR TITLE
Prep 0.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ project adheres to [Semantic Versioning][Semver].
   * WIP - extract plugins to separate gems ...
   * Your contribution here!
 
+## [0.7.0][] (13 July 2016)
+  * Last release supporting Ruby < 1.9.3
+
 ## [0.6.7][] (8 June 2016)
   * Remove `console` binary from packaged gem
 
@@ -241,7 +244,8 @@ project adheres to [Semantic Versioning][Semver].
   instead of compositing multiply image Caption objects (this seems to be more
   reliable to not glitch.)
 
-[Unreleased]: https://github.com/mroth/lolcommits/compare/v0.6.7...HEAD
+[Unreleased]: https://github.com/mroth/lolcommits/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/mroth/lolcommits/compare/v0.6.7...v0.7.0
 [0.6.7]: https://github.com/mroth/lolcommits/compare/v0.6.6...v0.6.7
 [0.6.6]: https://github.com/mroth/lolcommits/compare/v0.6.5...v0.6.6
 [0.6.5]: https://github.com/mroth/lolcommits/compare/v0.6.4...v0.6.5

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Please add your own lolcommit! Add to the [People Using
 Lolcommits](https://github.com/mroth/lolcommits/wiki/Lolcommits-from-around-the-world%21)
 page on our wiki.
 
+## Requirements
+
+* Ruby >= 1.8.7
+* A webcam
+* [ImageMagick](http://www.imagemagick.org)
+* [ffmpeg](https://www.ffmpeg.org) (optional) for animated gif capturing
+
 ## Installation
 
 ### Mac OS X
@@ -39,6 +46,11 @@ default MacOSX Ruby install is dumb and requires it.
 If [Boxen](https://boxen.github.com) is your thing, [try
 this](https://github.com/AssuredLabor/puppet-lolcommits).
 
+Lolcommits v0.7.0 was the last release to support Ruby < 1.9.3. If you'd like to
+use this gem on older rubies, install it with:
+
+    [sudo] gem install lolcommits --version 0.7.0
+
 ### Linux
 
 Install dependencies using your package manager of choice, for example in
@@ -46,7 +58,9 @@ Ubuntu:
 
     sudo apt-get install mplayer imagemagick libmagickwand-dev
 
-For Ubuntu 14.04 or newer, you need to manually install ffmpeg since it no longer ships with the default Ubuntu sources. [Downloads for ffmpeg](http://ffmpeg.org/download.html)
+For Ubuntu 14.04 or newer, you need to manually install ffmpeg since it no
+longer ships with the default Ubuntu sources. [Downloads for
+ffmpeg](http://ffmpeg.org/download.html)
 
 Then install the gem with:
 
@@ -118,12 +132,12 @@ in your repository's `.git/hooks/post-commit` file).
 * `--fork`
 * `--stealth`
 
-You can configure lolcommits to adjust the text positions, font styles (type, 
-size, color etc.) or add a transparent overlay to your images. Simply configure 
+You can configure lolcommits to adjust the text positions, font styles (type,
+size, color etc.) or add a transparent overlay to your images. Simply configure
 the default loltext plugin with this command:
 
     lolcommits --config -p loltext
-    
+
 To find out more, read about the [loltext options](https://github.com/mroth/lolcommits/wiki/Configure-Commit-Capturing#loltext-options).
 
 You can use `lolcommits --devices` to list all attached video devices available

--- a/lib/lolcommits/version.rb
+++ b/lib/lolcommits/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
-  VERSION = '0.6.7'.freeze
+  VERSION = '0.7.0'.freeze
 end


### PR DESCRIPTION
Preparing for 0.7.0 release, last release to support Ruby < 1.9.3.  CHANGELOG, README and version updated.