### PR TITLE
Drop ruby support upgrade gems

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,3 +55,7 @@ Style/CaseIndentation:
 # Offense count: 28
 Style/Documentation:
   Enabled: false
+
+# Bug with this cop https://github.com/bbatsov/rubocop/issues/3283
+Lint/ShadowedException:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
- - 1.8.7
  - 1.9.2
  - 1.9.3
  - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
- - 1.9.2
  - 1.9.3
  - 2.0.0
  - 2.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ project adheres to [Semantic Versioning][Semver].
   * WIP - extract plugins to separate gems ...
   * Your contribution here!
 
-## [0.7.0][] (13 July 2016)
+## [0.8.0][] (13 July 2016)
+  * New release requires Ruby 1.9.3+ minimum
+  * All gems upgraded to latest versions (6 held back, see lolcommits.gemspec)
+  * See [this issue](https://github.com/mroth/lolcommits/issues/310) for details
+
+## [0.7.0][] (13 July 2016) - Last release supporting Ruby < 1.9.3
   * Last release supporting Ruby < 1.9.3
 
 ## [0.6.7][] (8 June 2016)
@@ -244,7 +249,8 @@ project adheres to [Semantic Versioning][Semver].
   instead of compositing multiply image Caption objects (this seems to be more
   reliable to not glitch.)
 
-[Unreleased]: https://github.com/mroth/lolcommits/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/mroth/lolcommits/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/mroth/lolcommits/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mroth/lolcommits/compare/v0.6.7...v0.7.0
 [0.6.7]: https://github.com/mroth/lolcommits/compare/v0.6.6...v0.6.7
 [0.6.6]: https://github.com/mroth/lolcommits/compare/v0.6.5...v0.6.6

--- a/Rakefile
+++ b/Rakefile
@@ -47,14 +47,9 @@ Rake::RDocTask.new do |rd|
   rd.rdoc_files.include('README.rdoc', 'lib/**/*.rb', 'bin/**/*')
 end
 
-# only run rubocop on platforms where it is supported, sigh
-if RUBY_VERSION >= '1.9.3'
-  require 'rubocop/rake_task'
-  RuboCop::RakeTask.new
-  task :default => [:rubocop, :test, :features]
-else
-  task :default => [:test, :features]
-end
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+task :default => [:rubocop, :test, :features]
 
 desc 'Migrate an existing local .lolcommits directory to Dropbox'
 task :dropboxify do

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,7 @@ Rake::FileUtilsExt.verbose(false)
 CUKE_RESULTS = 'results.html'.freeze
 CLEAN << CUKE_RESULTS
 Cucumber::Rake::Task.new(:features) do |t|
-  optstr = "features --format html -o #{CUKE_RESULTS} --format Fivemat -x"
+  optstr = "features --format html -o #{CUKE_RESULTS} --format progress -x"
   optstr << " --tags @#{ENV['tag']}" unless ENV['tag'].nil?
   optstr << ' --tags ~@unstable' if ENV['tag'].nil? # ignore unstable tests unless specifying something at CLI
   t.cucumber_opts = optstr

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -165,7 +165,7 @@ Then(/^the output should contain a list of plugins$/) do
 end
 
 When(/^I do a git commit with commit message "(.*?)"$/) do |commit_msg|
-  filename = Faker::Lorem.words(1).first
+  filename = FFaker::Lorem.words(1).first
   steps %(
     Given a 98 byte file named "#{filename}"
     And I successfully run `git add #{filename}`
@@ -174,7 +174,7 @@ When(/^I do a git commit with commit message "(.*?)"$/) do |commit_msg|
 end
 
 When(/^I do a git commit$/) do
-  step %(I do a git commit with commit message "#{Faker::Lorem.sentence}")
+  step %(I do a git commit with commit message "#{FFaker::Lorem.sentence}")
 end
 
 When(/^I do (\d+) git commits$/) do |n|
@@ -190,7 +190,7 @@ Then(/^there should be (\d+) commit entries in the git log$/) do |n|
 end
 
 When(/^I do a mercurial commit with commit message "(.*?)"$/) do |commit_msg|
-  filename = Faker::Lorem.words(1).first
+  filename = FFaker::Lorem.words(1).first
   steps %(
     Given a 98 byte file named "#{filename}"
     And I successfully run `hg add #{filename}`
@@ -199,7 +199,7 @@ When(/^I do a mercurial commit with commit message "(.*?)"$/) do |commit_msg|
 end
 
 When(/^I do a mercurial commit$/) do
-  step %(I do a mercurial commit with commit message "#{Faker::Lorem.sentence}")
+  step %(I do a mercurial commit with commit message "#{FFaker::Lorem.sentence}")
 end
 
 When(/^I do (\d+) mercurial commits$/) do |n|

--- a/features/support/path_helpers.rb
+++ b/features/support/path_helpers.rb
@@ -24,7 +24,7 @@ module PathHelpers
     # add the temporary directory with git in it back into the path
     newpaths << tmpbindir
 
-    # use aruba/api set_env to set PATH, which will be automaticaly restored
+    # use aruba/api set_environment_variable to set PATH, which will be automaticaly restored
     set_env 'PATH', newpaths.join(File::PATH_SEPARATOR)
   end
 

--- a/lib/core_ext/mercurial-ruby/command.rb
+++ b/lib/core_ext/mercurial-ruby/command.rb
@@ -21,11 +21,7 @@ if Lolcommits::Platform.platform_windows?
             while (tmp = stderr.read(1024))
               error += tmp
             end
-            status = if RUBY_VERSION =~ /^1\.8/
-                       error.empty? ? 0 : 1
-                     else
-                       wait_thread.value
-                     end
+            status = wait_thread.value
           end
           raise_error_if_needed(status, error)
           result

--- a/lib/core_ext/string.rb
+++ b/lib/core_ext/string.rb
@@ -1,9 +1,0 @@
-# -*- encoding : utf-8 -*-
-if RUBY_VERSION =~ /^1\.8/
-  class String
-    # used unconditionally by mercurial-ruby
-    def encode(str, _options)
-      str
-    end
-  end
-end

--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -2,7 +2,6 @@
 $LOAD_PATH.unshift File.expand_path('.')
 
 require 'core_ext/class'
-require 'core_ext/string'
 require 'mini_magick'
 require 'core_ext/mini_magick/utilities'
 require 'fileutils'

--- a/lib/lolcommits/backends/installation_git.rb
+++ b/lib/lolcommits/backends/installation_git.rb
@@ -42,7 +42,7 @@ module Lolcommits
         f.write(hook_script)
       end
 
-      FileUtils.chmod 0755, HOOK_PATH
+      FileUtils.chmod 0o755, HOOK_PATH
       HOOK_PATH
     end
 

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -124,7 +124,7 @@ module Lolcommits
       if File.directory? loldir
         begin
           # ensure 755 permissions for loldir
-          File.chmod(0755, loldir)
+          File.chmod(0o755, loldir)
         rescue Errno::EPERM
           # abort if permissions cannot be met
           puts "FATAL: directory '#{loldir}' should be present and writeable by user '#{ENV['USER']}'"

--- a/lib/lolcommits/platform.rb
+++ b/lib/lolcommits/platform.rb
@@ -63,9 +63,9 @@ module Lolcommits
     def self.valid_imagemagick_installed?
       return false unless command_which('identify')
       return false unless command_which('mogrify')
-      # you'd expect the below to work on its own, but it only handles old versions
-      # and will throw an exception if IM is not installed in PATH
-      MiniMagick.valid_version_installed?
+      # cli_version check will throw a MiniMagick::Error exception if IM is not
+      # installed in PATH, since it attempts to parse output from `identify`
+      !MiniMagick.cli_version.nil?
     rescue
       return false
     end

--- a/lib/lolcommits/plugins/dot_com.rb
+++ b/lib/lolcommits/plugins/dot_com.rb
@@ -27,7 +27,8 @@ module Lolcommits
           :key   => configuration['api_key'],
           :t     => t,
           :token => Digest::SHA1.hexdigest(configuration['api_secret'] + t)
-        })
+        }
+      )
     rescue => e
       log_error(e, "ERROR: HTTMultiParty POST FAILED #{e.class} - #{e.message}")
     end

--- a/lib/lolcommits/plugins/lol_protonet.rb
+++ b/lib/lolcommits/plugins/lol_protonet.rb
@@ -37,17 +37,18 @@ module Lolcommits
     end
 
     def random_adjective
-      adjectives = ['awesome', 'great', 'interesting', 'cool', 'EPIC', 'gut', 'good', 'pansy',
-                    'powerful', 'boring', 'quirky', 'untested', 'german', 'iranian', 'neutral', 'crazy', 'well tested',
-                    'jimmy style', 'nasty', 'bibliographical (we received complaints about the original wording)',
-                    'bombdiggidy', 'narly', 'spiffy', 'smashing', 'xing style',
-                    'leo apotheker style', 'black', 'white', 'yellow', 'shaggy', 'tasty', 'mind bending', 'JAY-Z',
-                    'Kanye (the best ever)', '* Toby Keith was here *', 'splendid', 'stupendulous',
-                    '(freedom fries!)', '[vote RON PAUL]', '- these are not my glasses -', 'typical pansy',
-                    '- ze goggles zey do nothing! -', 'almost working', 'legen- wait for it -', '-dairy!',
-                    ' - Tavonius would be proud of this - ', 'Meg FAILMAN!', '- very brofessional of you -',
-                    'heartbleeding', 'juciy', 'supercalifragilisticexpialidocious', 'failing', 'loving'
-                   ]
+      adjectives = [
+        'awesome', 'great', 'interesting', 'cool', 'EPIC', 'gut', 'good', 'pansy',
+        'powerful', 'boring', 'quirky', 'untested', 'german', 'iranian', 'neutral', 'crazy', 'well tested',
+        'jimmy style', 'nasty', 'bibliographical (we received complaints about the original wording)',
+        'bombdiggidy', 'narly', 'spiffy', 'smashing', 'xing style',
+        'leo apotheker style', 'black', 'white', 'yellow', 'shaggy', 'tasty', 'mind bending', 'JAY-Z',
+        'Kanye (the best ever)', '* Toby Keith was here *', 'splendid', 'stupendulous',
+        '(freedom fries!)', '[vote RON PAUL]', '- these are not my glasses -', 'typical pansy',
+        '- ze goggles zey do nothing! -', 'almost working', 'legen- wait for it -', '-dairy!',
+        ' - Tavonius would be proud of this - ', 'Meg FAILMAN!', '- very brofessional of you -',
+        'heartbleeding', 'juciy', 'supercalifragilisticexpialidocious', 'failing', 'loving'
+      ]
       adjectives.sample
     end
 

--- a/lib/lolcommits/plugins/lol_slack.rb
+++ b/lib/lolcommits/plugins/lol_slack.rb
@@ -53,7 +53,8 @@ module Lolcommits
           :filetype => 'jpg',
           :filename => runner.sha,
           :title    => runner.message + "[#{runner.vcs_info.repo}]",
-          :channels => configuration['channels'])
+          :channels => configuration['channels']
+        )
 
         debug response
       rescue => e

--- a/lib/lolcommits/plugins/lol_tumblr.rb
+++ b/lib/lolcommits/plugins/lol_tumblr.rb
@@ -81,20 +81,22 @@ module Lolcommits
     end
 
     def client
-      @client ||= Tumblr.new(:consumer_key       => TUMBLR_CONSUMER_KEY,
-                             :consumer_secret    => TUMBLR_CONSUMER_SECRET,
-                             :oauth_token        => configuration['access_token'],
-                             :oauth_token_secret => configuration['secret']
-                            )
+      @client ||= Tumblr.new(
+        :consumer_key       => TUMBLR_CONSUMER_KEY,
+        :consumer_secret    => TUMBLR_CONSUMER_SECRET,
+        :oauth_token        => configuration['access_token'],
+        :oauth_token_secret => configuration['secret']
+      )
     end
 
     def oauth_consumer
-      @oauth_consumer ||= OAuth::Consumer.new(TUMBLR_CONSUMER_KEY,
-                                              TUMBLR_CONSUMER_SECRET,
-                                              :site             => TUMBLR_API_ENDPOINT,
-                                              :request_endpoint => TUMBLR_API_ENDPOINT,
-                                              :http_methdo => :get
-                                             )
+      @oauth_consumer ||= OAuth::Consumer.new(
+        TUMBLR_CONSUMER_KEY,
+        TUMBLR_CONSUMER_SECRET,
+        :site             => TUMBLR_API_ENDPOINT,
+        :request_endpoint => TUMBLR_API_ENDPOINT,
+        :http_method      => :get
+      )
     end
 
     def config_with_default(key, default = nil)

--- a/lib/lolcommits/plugins/lolsrv.rb
+++ b/lib/lolcommits/plugins/lolsrv.rb
@@ -29,8 +29,7 @@ module Lolcommits
     end
 
     def existing_lols
-      lols = JSON.parse(
-        RestClient.get(configuration['server'] + '/lols'))
+      lols = JSON.parse(RestClient.get(configuration['server'] + '/lols'))
       lols.map { |lol| lol['sha'] }
     rescue => e
       log_error(e, "ERROR: existing lols could not be retrieved #{e.class} - #{e.message}")

--- a/lib/lolcommits/plugins/uploldz.rb
+++ b/lib/lolcommits/plugins/uploldz.rb
@@ -25,18 +25,19 @@ module Lolcommits
         puts 'Repo is empty, skipping upload'
       else
         debug "Posting capture to #{configuration['endpoint']}"
-        RestClient.post(configuration['endpoint'],
-                        {
-                          :file         => File.new(runner.main_image),
-                          :message      => runner.message,
-                          :repo         => runner.vcs_info.repo,
-                          :author_name  => runner.vcs_info.author_name,
-                          :author_email => runner.vcs_info.author_email,
-                          :sha          => runner.sha,
-                          :key          => configuration['optional_key']
-                        },
-                        :Authorization => authorization_header
-                       )
+        RestClient.post(
+          configuration['endpoint'],
+          {
+            :file         => File.new(runner.main_image),
+            :message      => runner.message,
+            :repo         => runner.vcs_info.repo,
+            :author_name  => runner.vcs_info.author_name,
+            :author_email => runner.vcs_info.author_email,
+            :sha          => runner.sha,
+            :key          => configuration['optional_key']
+          },
+          :Authorization => authorization_header
+        )
       end
     rescue => e
       log_error(e, "ERROR: RestClient POST FAILED #{e.class} - #{e.message}")

--- a/lib/lolcommits/version.rb
+++ b/lib/lolcommits/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
-  VERSION = '0.7.0'.freeze
+  VERSION = '0.8.0'.freeze
 end

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -46,9 +46,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('git', '~> 1.3.0')
 
   # plugin gems
-  s.add_runtime_dependency('twitter', '~> 5.13.0')       # twitter
-  s.add_runtime_dependency('oauth', '~> 0.4.7')          # twitter oauth
-
+  s.add_runtime_dependency('twitter', '~> 5.16.0')       # twitter
   s.add_runtime_dependency('yam', '~> 2.5.0')            # yammer
   s.add_runtime_dependency('httmultiparty', '~> 0.3.16') # dot_com
   s.add_runtime_dependency('tumblr_client', '~> 0.8.5')  # tumblr

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   # hold back upgrading (and why)
   s.add_runtime_dependency('rest-client', '~> 1.8')       # yam gem requires uses this older version
-  s.add_runtime_dependency('mime-types', '~> 1.25')       # ~> 2+ requires Ruby >= 1.9.2
+  s.add_runtime_dependency('mime-types', '=2.99')         # ~> 3.0+ requires Ruby >= 2.0
   s.add_runtime_dependency('httparty', '~> 0.11.0')       # ~> 0.13+ requires Ruby >= 1.9.3
   s.add_development_dependency('cucumber', '=1.3.19')     # ~> 2+ requries Ruby >= 1.9.3
   s.add_development_dependency('tins', '=1.6.0')          # ~> 1.6+ requries Ruby >= 2.0
@@ -43,7 +43,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('mercurial-ruby', '~> 0')
   s.add_runtime_dependency('mini_magick', '~> 4.5.1')
   s.add_runtime_dependency('git', '~> 1.3.0')
-
 
   # plugin gems
   s.add_runtime_dependency('twitter', '~> 5.13.0')       # twitter

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -29,11 +29,11 @@ Gem::Specification.new do |s|
   s.requirements << 'a webcam'
 
   # hold back upgrading (and why)
-  s.add_runtime_dependency('rest-client', '~> 1.8')       # yam gem requires uses this older version
-  s.add_runtime_dependency('mime-types', '=2.99')         # ~> 3.0+ requires Ruby >= 2.0
-  s.add_runtime_dependency('httparty', '~> 0.11.0')       # ~> 0.13+ requires Ruby >= 1.9.3
-  s.add_development_dependency('cucumber', '=1.3.19')     # ~> 2+ requries Ruby >= 1.9.3
-  s.add_development_dependency('tins', '=1.6.0')          # ~> 1.6+ requries Ruby >= 2.0
+  s.add_runtime_dependency('rest-client', '=1.8')     # yam gem requires uses this older version
+  s.add_runtime_dependency('mime-types', '=2.99')     # ~> 3.0+ requires Ruby >= 2.0
+  s.add_runtime_dependency('httparty', '=0.13.0')     # ~> 0.13.1+ requires Ruby >= 1.9.3
+  s.add_development_dependency('cucumber', '=1.3.19') # ~> 2+ requries Ruby >= 1.9.3
+  s.add_development_dependency('tins', '=1.6.0')      # ~> 1.7+ requries Ruby >= 2.0
 
   # core
   s.add_runtime_dependency('choice', '~> 0.1.6')

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -29,15 +29,17 @@ Gem::Specification.new do |s|
   s.requirements << 'a webcam'
 
   # hold back upgrading (and why)
-  s.add_runtime_dependency('rest-client', '=1.8') # yam gem requires uses this older version
-  s.add_runtime_dependency('mime-types', '=2.99') # ~> 3.0+ requires Ruby >= 2.0
-  s.add_development_dependency('tins', '=1.6.0')  # ~> 1.7.0+ requires Ruby >= 2.0
+  s.add_runtime_dependency('rest-client', '=1.8')   # yam gem requires uses this older version
+  s.add_runtime_dependency('mime-types', '=2.99')   # ~> 3.0+ requires Ruby >= 2.0
+  s.add_runtime_dependency('json', '~> 1.8.3')      # ~> 2.0+ requires Ruby >= 2.0 (lolsrv)
+  s.add_development_dependency('tins', '=1.6.0')    # ~> 1.7.0+ requires Ruby >= 2.0
+  s.add_development_dependency('rake', '~> 10.5.0') # ~> 11+ introduces lots of warnings from other deps
 
   # core
-  s.add_runtime_dependency('choice', '~> 0.2.0')
   s.add_runtime_dependency('methadone', '~> 1.8.0')
-  s.add_runtime_dependency('mercurial-ruby', '~> 0')
 
+  s.add_runtime_dependency('choice', '~> 0.2.0')
+  s.add_runtime_dependency('mercurial-ruby', '~> 0.7.12')
   s.add_runtime_dependency('mini_magick', '~> 4.5.1')
   s.add_runtime_dependency('launchy', '~> 2.4.3')
   s.add_runtime_dependency('open4', '~> 1.3.4')
@@ -46,23 +48,21 @@ Gem::Specification.new do |s|
   # plugin gems
   s.add_runtime_dependency('twitter', '~> 5.13.0')       # twitter
   s.add_runtime_dependency('oauth', '~> 0.4.7')          # twitter oauth
-  s.add_runtime_dependency('json', '~> 1.8.1')           # lolsrv
 
   s.add_runtime_dependency('yam', '~> 2.5.0')            # yammer
   s.add_runtime_dependency('httmultiparty', '~> 0.3.16') # dot_com
   s.add_runtime_dependency('tumblr_client', '~> 0.8.5')  # tumblr
 
   # development gems
-  s.add_development_dependency('rdoc', '~> 4.2.0')
-  s.add_development_dependency('rake', '~> 10.4.2')
+  s.add_development_dependency('rdoc', '~> 4.2.2')
 
   # testing gems
   s.add_development_dependency('aruba', '~> 0.6.2')
-  s.add_development_dependency('ffaker', '~> 1.25.0')
-  s.add_development_dependency('coveralls', '~> 0.7.2')
-  s.add_development_dependency('minitest', '~> 5.5.1')
-  s.add_development_dependency('travis', '~> 1.7.4')
-  s.add_development_dependency('rubocop', '~> 0.37.2')
 
+  s.add_development_dependency('rubocop', '~> 0.41.0')
+  s.add_development_dependency('travis', '~> 1.8.2')
+  s.add_development_dependency('minitest', '~> 5.9.0')
+  s.add_development_dependency('coveralls', '~> 0.8.13')
+  s.add_development_dependency('ffaker', '~> 2.2.0')
   s.add_development_dependency('cucumber', '~> 2.4.0')
 end

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -24,16 +24,16 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # non-gem dependencies
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 1.9.1'
   s.requirements << 'imagemagick'
   s.requirements << 'a webcam'
 
   # hold back upgrading (and why)
   s.add_runtime_dependency('rest-client', '~> 1.6.7')   # yam gem requires uses this older version
-  s.add_runtime_dependency('mini_magick', '~> 4.5.1')   # ~> 4+ fails with JRuby
+  s.add_runtime_dependency('mini_magick', '~> 4.5.1')   #
+  s.add_runtime_dependency('git', '~> 1.3.0')           #
   s.add_runtime_dependency('mime-types', '~> 1.25')     # ~> 2+ requires Ruby >= 1.9.2
   s.add_runtime_dependency('httparty', '~> 0.11.0')     # ~> 0.13+ requires Ruby >= 1.9.3
-  s.add_runtime_dependency('git', '=1.2.8')             # ~> 1.2.9 has issues with Ruby 1.8.7
   s.add_development_dependency('cucumber', '=1.3.19')   # ~> 2+ requries Ruby >= 1.9.3
   s.add_development_dependency('tins', '=1.6.0')        # ~> 1.6+ requries Ruby >= 2.0
   s.add_development_dependency('addressable', '=2.3.8') # ~> 2.3+ requries Ruby >= 2.0

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   # hold back upgrading (and why)
   s.add_runtime_dependency('rest-client', '~> 1.6.7')   # yam gem requires uses this older version
-  s.add_runtime_dependency('mini_magick', '~> 3.8.1')   # ~> 4+ fails with JRuby
+  s.add_runtime_dependency('mini_magick', '~> 4.5.1')   # ~> 4+ fails with JRuby
   s.add_runtime_dependency('mime-types', '~> 1.25')     # ~> 2+ requires Ruby >= 1.9.2
   s.add_runtime_dependency('httparty', '~> 0.11.0')     # ~> 0.13+ requires Ruby >= 1.9.3
   s.add_runtime_dependency('git', '=1.2.8')             # ~> 1.2.9 has issues with Ruby 1.8.7

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -24,19 +24,16 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # non-gem dependencies
-  s.required_ruby_version = '>= 1.9.1'
+  s.required_ruby_version = '>= 1.9.2'
   s.requirements << 'imagemagick'
   s.requirements << 'a webcam'
 
   # hold back upgrading (and why)
-  s.add_runtime_dependency('rest-client', '~> 1.6.7')   # yam gem requires uses this older version
-  s.add_runtime_dependency('mini_magick', '~> 4.5.1')   #
-  s.add_runtime_dependency('git', '~> 1.3.0')           #
-  s.add_runtime_dependency('mime-types', '~> 1.25')     # ~> 2+ requires Ruby >= 1.9.2
-  s.add_runtime_dependency('httparty', '~> 0.11.0')     # ~> 0.13+ requires Ruby >= 1.9.3
-  s.add_development_dependency('cucumber', '=1.3.19')   # ~> 2+ requries Ruby >= 1.9.3
-  s.add_development_dependency('tins', '=1.6.0')        # ~> 1.6+ requries Ruby >= 2.0
-  s.add_development_dependency('addressable', '=2.3.8') # ~> 2.3+ requries Ruby >= 2.0
+  s.add_runtime_dependency('rest-client', '~> 1.8')       # yam gem requires uses this older version
+  s.add_runtime_dependency('mime-types', '~> 1.25')       # ~> 2+ requires Ruby >= 1.9.2
+  s.add_runtime_dependency('httparty', '~> 0.11.0')       # ~> 0.13+ requires Ruby >= 1.9.3
+  s.add_development_dependency('cucumber', '=1.3.19')     # ~> 2+ requries Ruby >= 1.9.3
+  s.add_development_dependency('tins', '=1.6.0')          # ~> 1.6+ requries Ruby >= 2.0
 
   # core
   s.add_runtime_dependency('choice', '~> 0.1.6')
@@ -44,14 +41,19 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('methadone', '~> 1.8.0')
   s.add_runtime_dependency('open4', '~> 1.3.4')
   s.add_runtime_dependency('mercurial-ruby', '~> 0')
+  s.add_runtime_dependency('mini_magick', '~> 4.5.1')
+  s.add_runtime_dependency('git', '~> 1.3.0')
+
 
   # plugin gems
   s.add_runtime_dependency('twitter', '~> 5.13.0')       # twitter
   s.add_runtime_dependency('oauth', '~> 0.4.7')          # twitter oauth
-  s.add_runtime_dependency('yam', '~> 2.4.0')            # yammer
+  s.add_runtime_dependency('yam', '~> 2.5.0')            # yammer
   s.add_runtime_dependency('json', '~> 1.8.1')           # lolsrv
   s.add_runtime_dependency('httmultiparty', '~> 0.3.16') # dot_com
   s.add_runtime_dependency('tumblr_client', '~> 0.8.5')  # tumblr
+
+  s.add_development_dependency('addressable', '~> 2.4.0')
 
   # development gems
   s.add_development_dependency('fivemat', '~> 1.3.1')

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |s|
   # hold back upgrading (and why)
   s.add_runtime_dependency('rest-client', '=1.8')     # yam gem requires uses this older version
   s.add_runtime_dependency('mime-types', '=2.99')     # ~> 3.0+ requires Ruby >= 2.0
-  s.add_development_dependency('cucumber', '=1.3.19') # ~> 2+ requries Ruby >= 1.9.3
-  s.add_development_dependency('tins', '=1.6.0')      # ~> 1.7+ requries Ruby >= 2.0
+
+  # s.add_development_dependency('tins', '=1.6.0')      # ~> 1.7+ requries Ruby >= 2.0
 
   # core
   s.add_runtime_dependency('choice', '~> 0.1.6')
@@ -52,15 +52,15 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('tumblr_client', '~> 0.8.5')  # tumblr
 
   # development gems
-  s.add_development_dependency('fivemat', '~> 1.3.1')
   s.add_development_dependency('rdoc', '~> 4.2.0')
-  s.add_development_dependency('aruba', '~> 0.6.2')
   s.add_development_dependency('rake', '~> 10.4.2')
+
+  # testing gems
+  s.add_development_dependency('cucumber', '~> 2.4.0')
+  s.add_development_dependency('aruba', '~> 0.6.2')
   s.add_development_dependency('ffaker', '~> 1.25.0')
   s.add_development_dependency('coveralls', '~> 0.7.2')
   s.add_development_dependency('minitest', '~> 5.5.1')
-
-  # testing gems
   s.add_development_dependency('travis', '~> 1.7.4')
   s.add_development_dependency('rubocop', '~> 0.37.2')
 end

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -34,10 +34,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('json', '~> 1.8.3')      # ~> 2.0+ requires Ruby >= 2.0 (lolsrv)
   s.add_development_dependency('tins', '=1.6.0')    # ~> 1.7.0+ requires Ruby >= 2.0
   s.add_development_dependency('rake', '~> 10.5.0') # ~> 11+ introduces lots of warnings from other deps
+  s.add_development_dependency('aruba', '~> 0.6.2') # upgrading requires a lot of test code changes
 
   # core
-  s.add_runtime_dependency('methadone', '~> 1.8.0')
-
+  s.add_runtime_dependency('methadone', '~> 1.9.2')
   s.add_runtime_dependency('choice', '~> 0.2.0')
   s.add_runtime_dependency('mercurial-ruby', '~> 0.7.12')
   s.add_runtime_dependency('mini_magick', '~> 4.5.1')
@@ -55,8 +55,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rdoc', '~> 4.2.2')
 
   # testing gems
-  s.add_development_dependency('aruba', '~> 0.6.2')
-
   s.add_development_dependency('rubocop', '~> 0.41.0')
   s.add_development_dependency('travis', '~> 1.8.2')
   s.add_development_dependency('minitest', '~> 5.9.0')

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -24,14 +24,13 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # non-gem dependencies
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 1.9.3'
   s.requirements << 'imagemagick'
   s.requirements << 'a webcam'
 
   # hold back upgrading (and why)
   s.add_runtime_dependency('rest-client', '=1.8')     # yam gem requires uses this older version
   s.add_runtime_dependency('mime-types', '=2.99')     # ~> 3.0+ requires Ruby >= 2.0
-  s.add_runtime_dependency('httparty', '=0.13.0')     # ~> 0.13.1+ requires Ruby >= 1.9.3
   s.add_development_dependency('cucumber', '=1.3.19') # ~> 2+ requries Ruby >= 1.9.3
   s.add_development_dependency('tins', '=1.6.0')      # ~> 1.7+ requries Ruby >= 2.0
 
@@ -51,8 +50,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('json', '~> 1.8.1')           # lolsrv
   s.add_runtime_dependency('httmultiparty', '~> 0.3.16') # dot_com
   s.add_runtime_dependency('tumblr_client', '~> 0.8.5')  # tumblr
-
-  s.add_development_dependency('addressable', '~> 2.4.0')
 
   # development gems
   s.add_development_dependency('fivemat', '~> 1.3.1')

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -29,25 +29,26 @@ Gem::Specification.new do |s|
   s.requirements << 'a webcam'
 
   # hold back upgrading (and why)
-  s.add_runtime_dependency('rest-client', '=1.8')     # yam gem requires uses this older version
-  s.add_runtime_dependency('mime-types', '=2.99')     # ~> 3.0+ requires Ruby >= 2.0
-
-  # s.add_development_dependency('tins', '=1.6.0')      # ~> 1.7+ requries Ruby >= 2.0
+  s.add_runtime_dependency('rest-client', '=1.8') # yam gem requires uses this older version
+  s.add_runtime_dependency('mime-types', '=2.99') # ~> 3.0+ requires Ruby >= 2.0
+  s.add_development_dependency('tins', '=1.6.0')  # ~> 1.7.0+ requires Ruby >= 2.0
 
   # core
-  s.add_runtime_dependency('choice', '~> 0.1.6')
-  s.add_runtime_dependency('launchy', '~> 2.4.3')
+  s.add_runtime_dependency('choice', '~> 0.2.0')
   s.add_runtime_dependency('methadone', '~> 1.8.0')
-  s.add_runtime_dependency('open4', '~> 1.3.4')
   s.add_runtime_dependency('mercurial-ruby', '~> 0')
+
   s.add_runtime_dependency('mini_magick', '~> 4.5.1')
+  s.add_runtime_dependency('launchy', '~> 2.4.3')
+  s.add_runtime_dependency('open4', '~> 1.3.4')
   s.add_runtime_dependency('git', '~> 1.3.0')
 
   # plugin gems
   s.add_runtime_dependency('twitter', '~> 5.13.0')       # twitter
   s.add_runtime_dependency('oauth', '~> 0.4.7')          # twitter oauth
-  s.add_runtime_dependency('yam', '~> 2.5.0')            # yammer
   s.add_runtime_dependency('json', '~> 1.8.1')           # lolsrv
+
+  s.add_runtime_dependency('yam', '~> 2.5.0')            # yammer
   s.add_runtime_dependency('httmultiparty', '~> 0.3.16') # dot_com
   s.add_runtime_dependency('tumblr_client', '~> 0.8.5')  # tumblr
 
@@ -56,11 +57,12 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake', '~> 10.4.2')
 
   # testing gems
-  s.add_development_dependency('cucumber', '~> 2.4.0')
   s.add_development_dependency('aruba', '~> 0.6.2')
   s.add_development_dependency('ffaker', '~> 1.25.0')
   s.add_development_dependency('coveralls', '~> 0.7.2')
   s.add_development_dependency('minitest', '~> 5.5.1')
   s.add_development_dependency('travis', '~> 1.7.4')
   s.add_development_dependency('rubocop', '~> 0.37.2')
+
+  s.add_development_dependency('cucumber', '~> 2.4.0')
 end

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -60,8 +60,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('coveralls', '~> 0.7.2')
   s.add_development_dependency('minitest', '~> 5.5.1')
 
-  if RUBY_VERSION >= '1.9.3'
-    s.add_development_dependency('travis', '~> 1.7.4')
-    s.add_development_dependency('rubocop', '~> 0.37.2')
-  end
+  # testing gems
+  s.add_development_dependency('travis', '~> 1.7.4')
+  s.add_development_dependency('rubocop', '~> 0.37.2')
 end

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -29,12 +29,12 @@ Gem::Specification.new do |s|
   s.requirements << 'a webcam'
 
   # hold back upgrading (and why)
-  s.add_runtime_dependency('rest-client', '=1.8')   # yam gem requires uses this older version
-  s.add_runtime_dependency('mime-types', '=2.99')   # ~> 3.0+ requires Ruby >= 2.0
-  s.add_runtime_dependency('json', '~> 1.8.3')      # ~> 2.0+ requires Ruby >= 2.0 (lolsrv)
-  s.add_development_dependency('tins', '=1.6.0')    # ~> 1.7.0+ requires Ruby >= 2.0
-  s.add_development_dependency('rake', '~> 10.5.0') # ~> 11+ introduces lots of warnings from other deps
-  s.add_development_dependency('aruba', '~> 0.6.2') # upgrading requires a lot of test code changes
+  s.add_runtime_dependency('rest-client', '=1.8') # yam gem requires uses this older version
+  s.add_runtime_dependency('mime-types', '=2.99') # ~> 3.0+ requires Ruby >= 2.0
+  s.add_runtime_dependency('json', '=1.8.3')      # ~> 2.0+ requires Ruby >= 2.0 (lolsrv)
+  s.add_development_dependency('tins', '=1.6.0')  # ~> 1.7.0+ requires Ruby >= 2.0
+  s.add_development_dependency('aruba', '=0.6.2') # upgrading requires a lot of test code changes
+  s.add_development_dependency('rake', '=10.5.0') # ~> 11+ introduces lots of warnings from other deps
 
   # core
   s.add_runtime_dependency('methadone', '~> 1.9.2')
@@ -58,7 +58,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop', '~> 0.41.0')
   s.add_development_dependency('travis', '~> 1.8.2')
   s.add_development_dependency('minitest', '~> 5.9.0')
-  s.add_development_dependency('coveralls', '~> 0.8.13')
+  s.add_development_dependency('coveralls', '~> 0.8.14')
   s.add_development_dependency('ffaker', '~> 2.2.0')
   s.add_development_dependency('cucumber', '~> 2.4.0')
 end

--- a/test/lolcommits_test.rb
+++ b/test/lolcommits_test.rb
@@ -1,8 +1,6 @@
 # -*- encoding : utf-8 -*-
-if RUBY_VERSION >= '2.0.0'
-  require 'coveralls'
-  Coveralls.wear!
-end
+require 'coveralls'
+Coveralls.wear!
 
 require 'minitest/autorun'
 
@@ -20,18 +18,18 @@ class LolTest < MiniTest::Test
   # this will test the permissions but only locally, important before building a gem package!
   #
   def test_permissions
-    impact_perms     = File.lstat(Lolcommits::Loltext::DEFAULT_FONT_PATH).mode & 0777
-    imagesnap_perms  = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'ext', 'imagesnap', 'imagesnap')).mode & 0777
-    videosnap_perms  = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'ext', 'videosnap', 'videosnap')).mode & 0777
-    commandcam_perms = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'ext', 'CommandCam', 'CommandCam.exe')).mode & 0777
+    impact_perms     = File.lstat(Lolcommits::Loltext::DEFAULT_FONT_PATH).mode & 0o777
+    imagesnap_perms  = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'ext', 'imagesnap', 'imagesnap')).mode & 0o777
+    videosnap_perms  = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'ext', 'videosnap', 'videosnap')).mode & 0o777
+    commandcam_perms = File.lstat(File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'ext', 'CommandCam', 'CommandCam.exe')).mode & 0o777
 
-    assert impact_perms == 0644 || impact_perms == 0664,
+    assert impact_perms == 0o644 || impact_perms == 0o664,
            "expected perms of 644/664 but instead got #{format '%o', impact_perms}"
-    assert imagesnap_perms == 0755 || imagesnap_perms == 0775,
+    assert imagesnap_perms == 0o755 || imagesnap_perms == 0o775,
            "expected perms of 755/775 but instead got #{format '%o', imagesnap_perms}"
-    assert videosnap_perms == 0755 || videosnap_perms == 0775,
+    assert videosnap_perms == 0o755 || videosnap_perms == 0o775,
            "expected perms of 755/775 but instead got #{format '%o', videosnap_perms}"
-    assert commandcam_perms == 0755 || commandcam_perms == 0775,
+    assert commandcam_perms == 0o755 || commandcam_perms == 0o775,
            "expected perms of 755/775 but instead got #{format '%o', commandcam_perms}"
   end
 end

--- a/test/lolcommits_test.rb
+++ b/test/lolcommits_test.rb
@@ -1,6 +1,8 @@
 # -*- encoding : utf-8 -*-
-require 'coveralls'
-Coveralls.wear!
+if RUBY_VERSION >= '2.0.0'
+  require 'coveralls'
+  Coveralls.wear!
+end
 
 require 'minitest/autorun'
 

--- a/test/plugins_test.rb
+++ b/test/plugins_test.rb
@@ -1,6 +1,8 @@
 # -*- encoding : utf-8 -*-
-require 'coveralls'
-Coveralls.wear!
+if RUBY_VERSION >= '2.0.0'
+  require 'coveralls'
+  Coveralls.wear!
+end
 
 require 'minitest/autorun'
 require 'ffaker'

--- a/test/plugins_test.rb
+++ b/test/plugins_test.rb
@@ -1,8 +1,6 @@
 # -*- encoding : utf-8 -*-
-if RUBY_VERSION >= '2.0.0'
-  require 'coveralls'
-  Coveralls.wear!
-end
+require 'coveralls'
+Coveralls.wear!
 
 require 'minitest/autorun'
 require 'ffaker'
@@ -29,7 +27,7 @@ class PluginsTest < MiniTest::Test
   #
   # issue #136, https://github.com/mroth/lolcommits/issues/136
   def test_lol_twitter_build_tweet
-    long_commit_message = Faker::Lorem.sentence(500)
+    long_commit_message = FFaker::Lorem.sentence(500)
     plugin              = Lolcommits::LolTwitter.new(nil)
     max_tweet_size      = 116
     suffix              = '... #lolcommits'


### PR DESCRIPTION
Drops support for Ruby < 1.9.3.  Upgraded all gems to their latest versions apart from the following;

```
s.add_runtime_dependency('rest-client', '=1.8')   # yam gem requires uses this older version           
s.add_runtime_dependency('mime-types', '=2.99')   # ~> 3.0+ requires Ruby >= 2.0                       
s.add_runtime_dependency('json', '~> 1.8.3')      # ~> 2.0+ requires Ruby >= 2.0 (lolsrv)       
       
s.add_development_dependency('tins', '=1.6.0')    # ~> 1.7.0+ requires Ruby >= 2.0                     
s.add_development_dependency('rake', '~> 10.5.0') # ~> 11+ introduces lots of warnings from other deps 
s.add_development_dependency('aruba', '~> 0.6.2') # upgrading requires a lot of test code changes      
```

Upgrading aruba requires significant effort, since they've changed and deprecated a lot since `0.6.2`. (could be done in the future)...

The main benefits are;

* we're on the latest versions of many more gems, including cucumber, rubocop and twitter
* we're on the latest MiniMagick, meaning snaps no longer text quoted on modern rubies
* future upgrade work is easier (including extracting plugins out)
* less legacy rubies to maintain going forward 👍 
* test runs are a little faster 🐎 

You can see from the gemspec that if we dropped Ruby 1.9 support and went right to 2.0+ we could update 2 more runtime gems and 1 test gem - Ruby1.9 (and even 2.0.0) are 'end of life' now - but lets leave that for the future