### PR TITLE
[#story-id] more permissive good_shebang? check

### DIFF
--- a/lib/lolcommits/backends/installation_git.rb
+++ b/lib/lolcommits/backends/installation_git.rb
@@ -99,7 +99,7 @@ EOS
 
     # does the git hook file have a good shebang?
     def self.good_shebang?
-      File.read(HOOK_PATH).lines.first =~ %r{^\#\!\/bin\/.*sh}
+      File.read(HOOK_PATH).lines.first =~ %r{^\#\!.*\/bin\/.*sh}
     end
 
     def self.remove_existing_hook!


### PR DESCRIPTION
### Why?

The shebang check is too strict, things like this are not considered
good:

     #!/usr/bin/env sh
     #!/usr/local/bin/env sh

### How?

Modified the `good_shebang?` method to allow shebang lines like this.
This is just a cursory check to ensure we don't have some wild text on
the first line of the post-commit hook.

Closes issue #316