### PR TITLE
Remove Choice gem, use Methadone

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/BlockLength:
 # Offense count: 5
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 146
+  Max: 160
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lolcommits (git + webcam = lol)
 
 lolcommits takes a snapshot with your webcam every time you git commit code, and
-archives a lolcat style image with it.  Git blame has never been so much fun.
+archives a lolcat style image with it. Git blame has never been so much fun.
 
 By default, the lol images are stored by a Github style short SHA in a
 `~/.lolcommits` directory created for you.
@@ -12,6 +12,7 @@ By default, the lol images are stored by a Github style short SHA in a
 [![CodeClimate Status](https://d3s6mut3hikguw.cloudfront.net/github/mroth/lolcommits/badges/gpa.svg)](https://codeclimate.com/github/mroth/lolcommits)
 [![Coverage Status](https://coveralls.io/repos/mroth/lolcommits/badge.svg?branch=master&service=github)](https://coveralls.io/r/mroth/lolcommits)
 
+
 ## Sample images
 
 <img src="https://lolcommits.github.io/assets/img/gallery.jpeg" />
@@ -20,19 +21,22 @@ Please add your own lolcommit! Add to the [People Using
 Lolcommits](https://github.com/mroth/lolcommits/wiki/Lolcommits-from-around-the-world%21)
 page on our wiki.
 
+
 ## Requirements
 
-* Ruby >= 1.8.7
+* Ruby >= 2.0.0
 * A webcam
 * [ImageMagick](http://www.imagemagick.org)
 * [ffmpeg](https://www.ffmpeg.org) (optional) for animated gif capturing
 
+
 ## Installation
+
 
 ### Mac OS X
 
 You'll need ImageMagick installed. [Homebrew](http://mxcl.github.com/homebrew/)
-makes this easy. Simply do:
+makes this easy.
 
 	brew install imagemagick
 
@@ -47,10 +51,11 @@ If [Boxen](https://boxen.github.com) is your thing, [try
 this](https://github.com/AssuredLabor/puppet-lolcommits).
 
 Lolcommits v0.8.1 was the last release to support Ruby < 2.0. If you'd like to
-use this gem on older rubies, install it with:
+use this gem on older rubies try:
 
     [sudo] gem install lolcommits --version 0.8.1   # for Ruby 1.9
     [sudo] gem install lolcommits --version 0.7.0   # for Ruby 1.8
+
 
 ### Linux
 
@@ -70,13 +75,16 @@ Then install the gem with:
 For more details, see [Installing on
 Linux](https://github.com/mroth/lolcommits/wiki/Installing-on-Linux).
 
+
 ### Windows - here be dragons!
 
-It all works but you'll need some more detailed instructions to get the
-dependencies installed.  See the wiki page for [Installing on
+It works, but you'll need some more detailed instructions to get the
+dependencies installed. See the wiki page for [Installing on
 Windows](https://github.com/mroth/lolcommits/wiki/Installing-on-Windows).
 
+
 ## Usage
+
 
 ### Enabling and basic usage
 
@@ -92,22 +100,26 @@ to achieve this using `git init` and the `init.templatedir` setting.
 Don't worry about it too much, half the fun of lolcommits is forgetting it's
 installed!
 
+
 ### Other commands
 
 Ok, if you insist... Since you know about `--enable`, common sense suggests
 there is also a repository specific `--disable`, hopefully you can guess what
-that does. Other handy common commands include `--last`, which will open for
-display your most recent lolcommit image, or `--browse`, which pops open the
-directory containing all the lolcommit images for your current repository. You
-can always do `--help` for a full list of available commands.
+that does.
 
-**NOTE**: Any extra arguments you pass with the --enable command are
-auto-appended to the git-commit capture command.  For example;
+Other handy common commands include `--last`, which will open for display your
+most recent lolcommit, or `--browse`, which pops open the directory containing
+all the lolcommit images for your current repository. You can always do `--help`
+for a full list of available commands.
 
-    lolcommits --enable --delay=5 --animate=4 --fork
+**NOTE**: Any extra arguments you pass with `--enable` are appended to the
+git post-hook capture command. For example;
+
+    lolcommits --enable --delay 5 --animate 4 --fork
 
 Will configure capturing of an animated gif (4 secs) after a 5 sec delay in a
 forked process. See the section below for more capture configuration variables.
+
 
 ### Capture configuration variables
 
@@ -124,27 +136,26 @@ via environment variables like so;
 * `LOLCOMMITS_STEALTH` disable notification messages at commit time
 * `LOLCOMMITS_DIR` set the output directory used for all repositories (defaults to ~/.lolcommits)
 
-Or they can be set via the following arguments in the capture command (located
-in your repository's `.git/hooks/post-commit` file).
+Or they can be set with these arguments to the capture command (located in your
+repository's `.git/hooks/post-commit` file).
 
-* `--device=DEVICE` or `-d DEVICE`
-* `--animate=SECONDS` or `-a SECONDS`
-* `--delay=SECONDS` or `-w SECONDS`
+* `--device {name}` or `-d {name}`
+* `--animate {seconds}` or `-a {seconds}`
+* `--delay {seconds}` or `-w {seconds}`
 * `--fork`
 * `--stealth`
 
-You can configure lolcommits to adjust the text positions, font styles (type,
-size, color etc.) or add a transparent overlay to your images. Simply configure
-the default loltext plugin with this command:
+Use `lolcommits --devices` to list all attached video devices available for
+capturing.
+
+You can configure lolcommit text positions, font styles (type, size, color etc.)
+or add a transparent overlay to your images. Simply configure the default
+loltext plugin with this command:
 
     lolcommits --config -p loltext
 
-To find out more, read about the [loltext options](https://github.com/mroth/lolcommits/wiki/Configure-Commit-Capturing#loltext-options).
+To find out more, read about [loltext options](https://github.com/mroth/lolcommits/wiki/Configure-Commit-Capturing#loltext-options).
 
-You can use `lolcommits --devices` to list all attached video devices available
-for capturing. Read how to [configure commit
-capturing](https://github.com/mroth/lolcommits/wiki/Configure-Commit-Capturing)
-for more details.
 
 ### Animated Gif Capturing
 
@@ -156,46 +167,45 @@ you capture and the capabilities of your machine).
 * OSX - `brew install ffmpeg`
 
 To enable, just set the `LOLCOMMITS_ANIMATE` environment variable with the
-number of seconds to capture. Like regular image captures you can use the env
-variables `LOLCOMMITS_DEVICE` and `LOLCOMMITS_DELAY` to change the capture
-device or delay time (seconds) before capturing.
-
-If you find capturing an animated gif takes too long, try setting the
-`LOLCOMMITS_FORK=true` env variable. Animated gif captures are currently NOT
+number of seconds to capture. If you find animated capturing takes too long, try
+setting `LOLCOMMITS_FORK=true`. Animated gif captures are currently NOT
 supported on Windows.
 
 ![Example animated lolcommit
 gif](http://cdn2.usa.bugleblogs.com/blogs/000/000/003/de0eb9aa695.gif "Example
 animated lolcommit gif")
 
+
 ### Plugins
 
-A growing number of plugins are now available allowing you to transform or share
+A growing number of plugins are available, allowing you to transform or share
 your lolcommits with others. The default plugin simply appends your commit
 message and sha to the captured image. Others can auto post to Twitter, Tumblr
 (and other services), or even translate your commit messages to
 [lolspeak](http://www.urbandictionary.com/define.php?term=lolspeak). They can be
-easily enabled, configured or disabled with our config command:
+easily enabled, configured or disabled with the `--config` option:
 
     lolcommits --config
 
 Check them out on our [plugins
 page](https://github.com/mroth/lolcommits/wiki/Configuring-Plugins).
 
+
+## Timelapse
+
+To watch your face as it decays while you program, you can create an animated
+timelapse gif.
+
+    lolcommits --timelapse
+    # or for just today's lolcommits
+    lolcommits --timelapse --period today
+
 ## Troubles?
 
 Try our trouble-shooting [FAQ](https://github.com/mroth/lolcommits/wiki/FAQ), or
 take a read through our [wiki](https://github.com/mroth/lolcommits/wiki) for
-more information. If you think something is broken or missing, raise a [GitHub
+more information. If you think something is broken or missing, raise a [Github
 issue](https://github.com/mroth/lolcommits/issues) (and please take a little
 time to check if we haven't [already
 addressed](https://github.com/mroth/lolcommits/issues?q=is%3Aissue+is%3Aclosed)
 it).
-
-## Timelapse?
-
-To watch your face as it decays while you program, you can create a quick mpeg
-of all your lolcommits snapshots (if you have `imagemagick` and `ffmpeg`
-installed):
-
-    convert `find . -type f -name "*.jpg" -print0 | xargs -0 ls -tlr | awk '{print $9}'` timelapse.mpeg

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -15,14 +15,13 @@ require 'lolcommits/cli.rb'
 # allow logging from everywhere
 include Methadone::CLILogging
 
-
 class App
   include Methadone::Main
 
   include Lolcommits
   include Lolcommits::CLI
 
-  description "git-based selfies for software developers (lolcommits.github.io)"
+  description 'git-based selfies for software developers (lolcommits.github.io)'
   version     Lolcommits::VERSION
 
   # TODO
@@ -36,7 +35,7 @@ class App
     else
       if debug_enabled?
         logger.level = Logger::DEBUG
-        debug "Outputting at DEBUG verbosity"
+        debug 'Outputting at DEBUG verbosity'
       end
 
       if options[:'show-config']
@@ -69,38 +68,38 @@ class App
     end
   end
 
-  on("--test", "run in test mode")
-  on("--debug", "show debugging info")
-  on("--show-config", "show configuration file")
-  on("--devices", "list available capture devices (mac only)")
-  on("--plugins", "list all available plugins")
-  on("--config", "configure a plugin")
+  on('--test', 'run in test mode')
+  on('--debug', 'show debugging info')
+  on('--show-config', 'show configuration file')
+  on('--devices', 'list available capture devices (mac only)')
+  on('--plugins', 'list all available plugins')
+  on('--config', 'configure a plugin')
 
-  on("-c", "--capture", "capture lolcommit based on last git commit")
-  on("-e", "--enable", "install lolcommits for this repo")
-  on("-d", "--disable", "uninstall lolcommits for this repo")
-  on("-l", "--last", "view the most recent lolcommit")
-  on("-b", "--browse", "browse this repo's lolcommits")
-  on("-t", "--timeline {today}", "generate animated gif from all (or today's) captured images")
-  on("-p", "--plugin {name}", "plugin name to use with --config")
+  on('-c', '--capture', 'capture lolcommit based on last git commit')
+  on('-e', '--enable', 'install lolcommits for this repo')
+  on('-d', '--disable', 'uninstall lolcommits for this repo')
+  on('-l', '--last', 'view the most recent lolcommit')
+  on('-b', '--browse', 'browse this repo\'s lolcommits')
+  on('-t', '--timeline {today}', 'generate animated gif from all (or today\'s) captured images')
+  on('-p', '--plugin {name}', 'plugin name to use with --config')
 
   # optional capturing options
-  on("--device {name}", "device name to capture from (mac/linux only)")
-  on("-a", "--animate {seconds}", "enable animated gif captures with duration")
-  on("-w", "--delay {seconds}", "delay before taking a snapshot")
-  on("--stealth", "capture image in stealth mode (no output)")
-  on("--fork", "fork capturing process to the background")
-  on("-s", "--sha {string}", "pass commit sha manually (--test mode only)")
-  on("-m", "--msg {string}", "pass commit message manually (--test mode only)")
+  on('--device {name}', 'device name to capture from (mac/linux only)')
+  on('-a', '--animate {seconds}', 'enable animated gif captures with duration')
+  on('-w', '--delay {seconds}', 'delay before taking a snapshot')
+  on('--stealth', 'capture image in stealth mode (no output)')
+  on('--fork', 'fork capturing process to the background')
+  on('-s', '--sha {string}', 'pass commit sha manually (--test mode only)')
+  on('-m', '--msg {string}', 'pass commit message manually (--test mode only)')
 
   #
   # No options specified, help the user out
   #
   def self.no_options_help
     # TODO: make this a contextual helper to know whether lolcommits is enabled
-    "Do what exactly?\n" +
-    "Try: lolcommits --enable (when in a git repository)\n" +
-    "Or:  lolcommits --help"
+    "Do what exactly?\n" \
+      "Try: lolcommits --enable (when in a git repository)\n" \
+      'Or:  lolcommits --help'
   end
 
   # Gets a configuration object.  If running in test mode will override the
@@ -109,7 +108,7 @@ class App
   # @return [Lolcommits::Configuration]
   def self.configuration
     if options[:test]
-      Configuration.new(loldir: Configuration.loldir_for('test'))
+      Configuration.new(:loldir => Configuration.loldir_for('test'))
     else
       Configuration.new
     end
@@ -151,19 +150,13 @@ class App
       :config          => configuration
     }
 
-
     process_runner = ProcessRunner.new(configuration)
     process_runner.fork_me?(should_we_fork) do
       if options[:test]
         info '*** Capturing in Test mode ***'
-        capture_options.merge!(message: options[:msg], sha: options[:sha])
+        capture_options[:message] = options[:msg]
+        capture_options[:sha] = options[:sha]
       end
-
-      puts "CAPTURING WITH: "
-      puts capture_options.inspect
-      puts "forkin? #{should_we_fork}"
-
-      return
 
       runner = Lolcommits::Runner.new(capture_options)
       runner.run

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -24,12 +24,7 @@ class App
   description 'git-based selfies for software developers (lolcommits.github.io)'
   version     Lolcommits::VERSION
 
-  # TODO
-  #   HANDLE custom ENV options (cmdline args override)
-
   main do
-    puts options.inspect
-
     if options.empty?
       puts no_options_help
     else

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -8,333 +8,228 @@ rescue LoadError
   require 'lolcommits'
 end
 
-require 'lolcommits/cli/fatals'
-require 'lolcommits/cli/launcher'
-require 'lolcommits/cli/process_runner'
-require 'lolcommits/cli/timelapse_gif'
-
-include Lolcommits
-include Lolcommits::CLI
-
-require 'choice'
+require 'optparse'
 require 'methadone'
+require 'lolcommits/cli.rb'
+
+# allow logging from everywhere
 include Methadone::CLILogging
 
-#
-# NO ARGUMENTS SPECIFIED, HELP THE USER OUT
-#
-def do_noargs
-  # TODO: make this a contextual helper to know whether lolcommits is enabled
-  puts 'Do what exactly?'
-  puts 'Try: lolcommits --enable   (when in a git repository)'
-  puts 'Or:  lolcommits --help'
-end
 
-# Gets a configuration object.  If running in test mode will override the
-# LOLDIR for the configuration.
-#
-# @return [Lolcommits::Configuration]
-def configuration
-  if Choice.choices[:test]
-    Configuration.new(loldir: Configuration.loldir_for('test'))
-  else
-    Configuration.new
-  end
-end
+class App
+  include Methadone::Main
 
-# Duration for animated capture.
-#
-# If animation is enabled, returns an integer representing seconds OR a string
-# containing the char representation of an integer.
-# If animation is disabled, or if the platform doesn't support animated capture,
-# returns nil instead.
-#
-# FIXME: we really should standardize this to always return integer, and remove
-#   all the to_i calls elsewhere.
-#
-# @return [Integer, String, nil]
-def capture_animate
-  return unless Platform.can_animate?
-  Choice.choices[:animate] || ENV['LOLCOMMITS_ANIMATE'] || nil
-end
+  include Lolcommits
+  include Lolcommits::CLI
 
-def default_device
-  result = Choice.choices[:device] || ENV['LOLCOMMITS_DEVICE']
+  description "git-based selfies for software developers (lolcommits.github.io)"
+  version     Lolcommits::VERSION
 
-  result ||= Dir.glob('/dev/video*').first if Platform.platform_linux?
+  # TODO
+  #   HANDLE custom ENV options (cmdline args override)
 
-  result
-end
+  main do
+    puts options.inspect
 
-#
-# IF --CAPTURE, DO CAPTURE
-#
-def do_capture
-  capture_delay   = Choice.choices[:delay] || ENV['LOLCOMMITS_DELAY'] || 0
-  capture_stealth = Choice.choices[:stealth] || ENV['LOLCOMMITS_STEALTH'] || nil
-  capture_device  = default_device
-
-  capture_options = {
-    capture_delay: capture_delay,
-    capture_stealth: capture_stealth,
-    capture_device: capture_device,
-    capture_animate: capture_animate,
-    config: configuration
-  }
-
-  process_runner = ProcessRunner.new(configuration)
-  should_we_fork = Choice.choices[:fork] || ENV['LOLCOMMITS_FORK']
-  process_runner.fork_me?(should_we_fork) do
-    if Choice.choices[:test]
-      info '*** Capturing in test mode.'
-
-      # get optional fake commit msg and sha from command line
-      override_text = {
-        message: Choice.choices[:msg],
-        sha: Choice.choices[:sha]
-      }
-
-      # fire off runner with the overriden fake commit metadata
-      runner = Lolcommits::Runner.new(capture_options.merge(override_text))
-      runner.run
-
-      # automatically open so user can see the test image results immediately
-      Launcher.open_image(runner.main_image)
+    if options.empty?
+      puts no_options_help
     else
+      if debug_enabled?
+        logger.level = Logger::DEBUG
+        debug "Outputting at DEBUG verbosity"
+      end
+
+      if options[:'show-config']
+        puts configuration
+      elsif options[:plugins]
+        puts configuration.plugins_list
+      elsif options[:devices]
+        puts Platform.device_list
+        puts device_list_help
+      elsif options[:enable]
+        Installation.do_enable
+      elsif options[:disable]
+        Installation.do_disable
+      else
+        # all other commands require a vcs repo
+        Fatals.die_if_not_vcs_repo!
+
+        if options[:last]
+          show_last_lolimage
+        elsif options[:browse]
+          Launcher.open_folder(configuration.loldir)
+        elsif options[:timeline]
+          TimelapseGif.new(configuration).run(options[:timeline])
+        elsif options[:config]
+          configuration.do_configure!(options[:plugin])
+        elsif options[:capture]
+          capture_lolcommit
+        end
+      end
+    end
+  end
+
+  on("--test", "run in test mode")
+  on("--debug", "show debugging info")
+  on("--show-config", "show configuration file")
+  on("--devices", "list available capture devices (mac only)")
+  on("--plugins", "list all available plugins")
+  on("--config", "configure a plugin")
+
+  on("-c", "--capture", "capture lolcommit based on last git commit")
+  on("-e", "--enable", "install lolcommits for this repo")
+  on("-d", "--disable", "uninstall lolcommits for this repo")
+  on("-l", "--last", "view the most recent lolcommit")
+  on("-b", "--browse", "browse this repo's lolcommits")
+  on("-t", "--timeline {today}", "generate animated gif from all (or today's) captured images")
+  on("-p", "--plugin {name}", "plugin name to use with --config")
+
+  # optional capturing options
+  on("--device {name}", "device name to capture from (mac/linux only)")
+  on("-a", "--animate {seconds}", "enable animated gif captures with duration")
+  on("-w", "--delay {seconds}", "delay before taking a snapshot")
+  on("--stealth", "capture image in stealth mode (no output)")
+  on("--fork", "fork capturing process to the background")
+  on("-s", "--sha {string}", "pass commit sha manually (--test mode only)")
+  on("-m", "--msg {string}", "pass commit message manually (--test mode only)")
+
+  #
+  # No options specified, help the user out
+  #
+  def self.no_options_help
+    # TODO: make this a contextual helper to know whether lolcommits is enabled
+    "Do what exactly?\n" +
+    "Try: lolcommits --enable (when in a git repository)\n" +
+    "Or:  lolcommits --help"
+  end
+
+  # Gets a configuration object.  If running in test mode will override the
+  # LOLDIR for the configuration.
+  #
+  # @return [Lolcommits::Configuration]
+  def self.configuration
+    if options[:test]
+      Configuration.new(loldir: Configuration.loldir_for('test'))
+    else
+      Configuration.new
+    end
+  end
+
+  def self.debug_enabled?
+    options[:debug] || ENV['LOLCOMMITS_DEBUG'] || false
+  end
+
+  def self.device_list_help
+    'Specify a device with --device "{device name}" or set the LOLCOMMITS_DEVICE env variable'
+  end
+
+  def self.show_last_lolimage
+    lolimage = configuration.most_recent
+    if lolimage.nil?
+      warn 'No lolcommits have been captured for this repository yet.'
+      exit 1
+    end
+    Launcher.open_image(lolimage)
+  end
+
+  def self.capture_device
+    result = options[:device] || ENV['LOLCOMMITS_DEVICE'] || nil
+    result ||= Dir.glob('/dev/video*').first if Platform.platform_linux?
+    result
+  end
+
+  def self.capture_lolcommit
+    should_we_fork  = options[:fork] || ENV['LOLCOMMITS_FORK'] || false
+    capture_stealth = options[:stealth] || ENV['LOLCOMMITS_STEALTH'] || false
+    capture_delay   = (options[:delay] || ENV['LOLCOMMITS_DELAY']).to_i
+
+    capture_options = {
+      :capture_delay   => capture_delay,
+      :capture_stealth => capture_stealth,
+      :capture_device  => capture_device,
+      :capture_animate => capture_animate,
+      :config          => configuration
+    }
+
+
+    process_runner = ProcessRunner.new(configuration)
+    process_runner.fork_me?(should_we_fork) do
+      if options[:test]
+        info '*** Capturing in Test mode ***'
+        capture_options.merge!(message: options[:msg], sha: options[:sha])
+      end
+
+      puts "CAPTURING WITH: "
+      puts capture_options.inspect
+      puts "forkin? #{should_we_fork}"
+
+      return
+
       runner = Lolcommits::Runner.new(capture_options)
       runner.run
-    end
-  end
-end
 
-def do_configure
-  Fatals.die_if_not_vcs_repo!
-  $stdout.sync = true
-  configuration.do_configure! Choice.choices[:plugin]
-end
-
-def do_last
-  Fatals.die_if_not_vcs_repo!
-  lolimage = configuration.most_recent
-  if lolimage.nil?
-    warn 'No lolcommits have been captured for this repository yet.'
-    exit 1
-  end
-  Launcher.open_image(lolimage)
-end
-
-def print_version_and_exit
-  puts Lolcommits::VERSION
-  exit 0
-end
-
-def change_dir_to_root_or_repo!
-  debug 'Walking up dir tree'
-  loop do
-    cur = File.expand_path('.')
-    nxt = File.expand_path('..', cur)
-    if nxt == cur
-      warn 'Repository root not found'
-      return
-    end
-    return if VCSInfo.repo_root?
-    Dir.chdir(nxt)
-  end
-end
-
-# FIXME: this should be moved out of the CLI, but to where?
-def load_local_plugins!
-  plugins_dir = Configuration.loldir_for('.plugins')
-  Dir.glob("#{plugins_dir}/*.rb").each do |plugin|
-    load plugin
-  end
-end
-
-#
-# Command line parsing fun
-#
-Choice.options do
-  option :version do
-    long '--version'
-    short '-v'
-    desc 'print version and exit'
-    action { print_version_and_exit }
-  end
-
-  option :enable do
-    long '--enable'
-    short '-e'
-    desc 'install lolcommits for this repo'
-    action do
-      Installation.do_enable
-      exit 0
+      # automatically open the image in test mode
+      Launcher.open_image(runner.main_image) if options[:test]
     end
   end
 
-  option :disable do
-    long '--disable'
-    short '-d'
-    desc 'uninstall lolcommits for this repo'
-    action do
-      Installation.do_disable
-      exit 0
+  # Duration for animated capturing
+  #
+  # If animation is enabled, returns an integer > 0 representing seconds.
+  # Seconds will be 0 if no option set, or if the platform doesn't support
+  # animated captures (in which case animated capturing will be disabled).
+  #
+  # @return [Integer]
+  def self.capture_animate
+    if Platform.can_animate?
+      (options[:animate] || ENV['LOLCOMMITS_ANIMATE']).to_i
+    else
+      0
     end
   end
 
-  option :capture do
-    long '--capture'
-    short '-c'
-    desc 'capture lolcommit based on last git commit'
+  def self.capture_animated?
+    capture_animate > 0
   end
 
-  option :last do
-    long '--last'
-    short '-l'
-    desc 'view the most recent lolcommit'
-  end
-
-  option :browse do
-    long '--browse'
-    short '-b'
-    desc "browse this repo's lolcommits"
-  end
-
-  option :configure do
-    long '--config'
-    desc 'configure a plugin'
-  end
-
-  option :show_config do
-    short '-sc'
-    long '--show-config'
-    desc 'display configuration file'
-  end
-
-  option :plugin do
-    desc 'pass plugin name for --config'
-    long '--plugin'
-    short '-p'
-    default nil
-  end
-
-  option :plugins do
-    desc 'list all available plugins'
-    long '--plugins'
-  end
-
-  option :test do
-    long '--test'
-    desc 'Run in test mode'
-  end
-
-  option :sha do
-    desc 'pass SHA manually [TEST-MODE]'
-    long '--sha'
-    short '-s'
-    default "test-#{rand(10**10)}"
-  end
-
-  option :msg do
-    desc 'pass commit msg manually [TEST-MODE]'
-    long '--msg'
-    short '-m'
-    default 'this is a test message i didnt really commit something'
-  end
-
-  option :delay do
-    long '--delay=SECONDS'
-    desc 'delay taking of the snapshot by n seconds'
-    cast Integer
-    short '-w'
-  end
-
-  option :stealth do
-    long '--stealth'
-    desc 'capture image in stealth mode'
-  end
-
-  option :device do
-    long '--device=DEVICE'
-    desc 'the device name used to take the snapshot (mac/linux only)'
-  end
-
-  option :devices do
-    long '--devices'
-    desc 'list all video devices available (mac only)'
-  end
-
-  option :debug do
-    long '--debug'
-    desc 'output debugging information'
-  end
-
-  option :gif do
-    long '--gif'
-    short '-g'
-    desc 'generate animated timeline gif from captured images'
-  end
-
-  if Platform.can_animate?
-    option :animate do
-      long '--animate=SECONDS'
-      short '-a'
-      cast Integer
-      desc 'enable animated gif captures with duration (seconds)'
+  # TODO: remove this after implementing gem based plugins
+  # https://github.com/mroth/lolcommits/issues/99
+  # Until then for local plugin dev, use $LOLCOMMITS_DIR/.plugins directory
+  def self.load_local_plugins!
+    plugins_dir = Configuration.loldir_for('.plugins')
+    Dir.glob("#{plugins_dir}/*.rb").each do |plugin|
+      load plugin
     end
   end
 
-  option :fork do
-    long '--fork'
-    desc 'fork the lolcommits runner to the background'
+  #
+  # change working dir to either a repo or the fs root
+  #
+  def self.change_dir_to_root_or_repo!
+    debug 'Walking up dir tree'
+    loop do
+      cur = File.expand_path('.')
+      nxt = File.expand_path('..', cur)
+      if nxt == cur
+        warn 'Repository root not found'
+        return
+      end
+      return if VCSInfo.repo_root?
+      Dir.chdir(nxt)
+    end
   end
-end
 
-# Set debug level if needed
-debug_mode = Choice.choices[:debug] || ENV['LOLCOMMITS_DEBUG'] || nil
-if debug_mode
-  logger.level = Logger::DEBUG
-  debug 'Outputting at DEBUG verbosity'
-end
+  #
+  # check for fatal conditions before execution
+  #
+  Fatals.die_if_no_valid_ffmpeg_installed! if capture_animated?
+  Fatals.die_on_fatal_platform_conditions!
 
-#
-# check for fatal conditions before execution
-#
-Fatals.die_if_no_valid_ffmpeg_installed! if capture_animate
-Fatals.die_on_fatal_platform_conditions!
+  #
+  # load plugins and walk up dir
+  #
+  load_local_plugins!
+  change_dir_to_root_or_repo!
 
-#
-# change working dir to either a repo or the fs root
-#
-change_dir_to_root_or_repo!
-
-# TODO: Allow local backend definitions?
-
-#
-# load system local plugins
-#
-load_local_plugins!
-
-#
-# Handle actions manually since choice seems weird
-#
-if Choice.choices[:capture]
-  do_capture
-elsif Choice.choices[:configure]
-  do_configure
-elsif Choice.choices[:show_config]
-  puts configuration
-elsif Choice.choices[:plugins]
-  configuration.puts_plugins
-elsif Choice.choices[:devices]
-  puts Platform.device_list
-  puts 'Specify a device with --device="{device name}" or set the LOLCOMMITS_DEVICE env variable'
-elsif Choice.choices[:last]
-  do_last
-elsif Choice.choices[:browse]
-  Fatals.die_if_not_vcs_repo!
-  Launcher.open_folder(configuration.loldir)
-elsif Choice.choices[:gif]
-  TimelapseGif.new(configuration).run(Choice.choices[:gif])
-else
-  do_noargs
+  go!
 end

--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -21,10 +21,14 @@ class App
   include Lolcommits
   include Lolcommits::CLI
 
-  description 'git-based selfies for software developers (lolcommits.github.io)'
+  description 'git-based selfies for software developers (https://lolcommits.github.io)'
   version     Lolcommits::VERSION
 
   main do
+    # check for fatal conditions before execution
+    Fatals.die_if_no_valid_ffmpeg_installed! if capture_animated?
+    Fatals.die_on_fatal_platform_conditions!
+
     if options.empty?
       puts no_options_help
     else
@@ -41,19 +45,23 @@ class App
         puts Platform.device_list
         puts device_list_help
       elsif options[:enable]
-        Installation.do_enable
+        Installation.do_enable(options)
       elsif options[:disable]
         Installation.do_disable
       else
-        # all other commands require a vcs repo
-        Fatals.die_if_not_vcs_repo!
+        # all other commands require a vcs repo, check its present and walk up
+        # to the root dir
+        unless options[:test]
+          Fatals.die_if_not_vcs_repo!
+          change_dir_to_root_or_repo!
+        end
 
         if options[:last]
           show_last_lolimage
         elsif options[:browse]
           Launcher.open_folder(configuration.loldir)
-        elsif options[:timeline]
-          TimelapseGif.new(configuration).run(options[:timeline])
+        elsif options[:timelapse]
+          TimelapseGif.new(configuration).run(options[:period])
         elsif options[:config]
           configuration.do_configure!(options[:plugin])
         elsif options[:capture]
@@ -69,14 +77,16 @@ class App
   on('--devices', 'list available capture devices (mac only)')
   on('--plugins', 'list all available plugins')
   on('--config', 'configure a plugin')
+  on('-p', '--plugin {name}', 'plugin name to use with --config')
 
   on('-c', '--capture', 'capture lolcommit based on last git commit')
   on('-e', '--enable', 'install lolcommits for this repo')
   on('-d', '--disable', 'uninstall lolcommits for this repo')
   on('-l', '--last', 'view the most recent lolcommit')
   on('-b', '--browse', 'browse this repo\'s lolcommits')
-  on('-t', '--timeline {today}', 'generate animated gif from all (or today\'s) captured images')
-  on('-p', '--plugin {name}', 'plugin name to use with --config')
+
+  on('--timelapse', 'generate animated timelapse gif from captured images')
+  on('--period {today}', 'period to use for the timelapse gif (today or all)')
 
   # optional capturing options
   on('--device {name}', 'device name to capture from (mac/linux only)')
@@ -103,7 +113,7 @@ class App
   # @return [Lolcommits::Configuration]
   def self.configuration
     if options[:test]
-      Configuration.new(:loldir => Configuration.loldir_for('test'))
+      Configuration.new(loldir: Configuration.loldir_for('test'))
     else
       Configuration.new
     end
@@ -138,19 +148,18 @@ class App
     capture_delay   = (options[:delay] || ENV['LOLCOMMITS_DELAY']).to_i
 
     capture_options = {
-      :capture_delay   => capture_delay,
-      :capture_stealth => capture_stealth,
-      :capture_device  => capture_device,
-      :capture_animate => capture_animate,
-      :config          => configuration
+      capture_delay: capture_delay,
+      capture_stealth: capture_stealth,
+      capture_device: capture_device,
+      capture_animate: capture_animate,
+      config: configuration
     }
 
     process_runner = ProcessRunner.new(configuration)
     process_runner.fork_me?(should_we_fork) do
       if options[:test]
-        info '*** Capturing in Test mode ***'
-        capture_options[:message] = options[:msg]
-        capture_options[:sha] = options[:sha]
+        info '*** Capturing in test mode.'
+        capture_options.merge!(test_capture_options)
       end
 
       runner = Lolcommits::Runner.new(capture_options)
@@ -159,6 +168,13 @@ class App
       # automatically open the image in test mode
       Launcher.open_image(runner.main_image) if options[:test]
     end
+  end
+
+  def self.test_capture_options
+    {
+      message: options[:msg] || 'this is a test message i didnt really commit something',
+      sha: options[:sha] || "test-#{rand(10**10)}"
+    }
   end
 
   # Duration for animated capturing
@@ -208,16 +224,9 @@ class App
   end
 
   #
-  # check for fatal conditions before execution
-  #
-  Fatals.die_if_no_valid_ffmpeg_installed! if capture_animated?
-  Fatals.die_on_fatal_platform_conditions!
-
-  #
-  # load plugins and walk up dir
+  # load plugins
   #
   load_local_plugins!
-  change_dir_to_root_or_repo!
 
   go!
 end

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -47,8 +47,8 @@ Feature: Basic UI functionality
 
   Scenario: Enable in a git repo passing capture arguments
     Given I am in a git repo
-    When I successfully run `lolcommits --enable -w 5 --fork`
-    Then the git post-commit hook should contain "lolcommits --capture -w 5 --fork"
+    When I successfully run `lolcommits --enable -w 5 --fork --stealth --device 'My Devce'`
+    Then the git post-commit hook should contain "lolcommits --capture --delay 5 --fork --stealth --device 'My Devce'"
     And the exit status should be 0
 
   Scenario: Disable in a enabled git repo
@@ -70,7 +70,7 @@ Feature: Basic UI functionality
   Scenario: Capture doesnt break in forked mode
     Given I am in a git repo named "forked"
     And I do a git commit
-    When I successfully run `lolcommits --capture --fork`
+    When I run `lolcommits --capture --fork`
     Then there should be exactly 1 pid in "~/.lolcommits/forked"
     When I wait for the child process to exit in "forked"
     Then a directory named "~/.lolcommits/forked" should exist
@@ -270,7 +270,7 @@ Feature: Basic UI functionality
   Scenario: generate gif should store in its own archive directory
     Given I am in a git repo named "giffy" with lolcommits enabled
       And a loldir named "giffy" with 2 lolimages
-    When I successfully run `lolcommits -g`
+    When I successfully run `lolcommits --timelapse`
     Then the output should contain "Generating animated gif."
       And a directory named "~/.lolcommits/giffy/archive" should exist
       And a file named "~/.lolcommits/giffy/archive/archive.gif" should exist
@@ -278,7 +278,7 @@ Feature: Basic UI functionality
   Scenario: generate gif with argument 'today'
     Given I am in a git repo named "sunday" with lolcommits enabled
       And a loldir named "sunday" with 2 lolimages
-    When I successfully run `lolcommits -g today`
+    When I successfully run `lolcommits --timelapse --period today`
     Then there should be exactly 1 gif in "~/.lolcommits/sunday/archive"
 
   @mac-only
@@ -295,7 +295,7 @@ Feature: Basic UI functionality
   @fake-no-ffmpeg
   Scenario: gracefully fail when ffmpeg not installed and --animate is used
     Given I am using a "darwin" platform
-    When I run `lolcommits --animate=3`
+    When I run `lolcommits -c --animate 3`
     Then the output should contain:
       """
       ffmpeg does not appear to be properly installed
@@ -328,7 +328,7 @@ Feature: Basic UI functionality
   Scenario: Enable in a mercurial repo passing capture arguments
     Given I am in a mercurial repo
     When I successfully run `lolcommits --enable -w 5 --fork`
-    Then the mercurial post-commit hook should contain "lolcommits --capture -w 5 --fork"
+    Then the mercurial post-commit hook should contain "lolcommits --capture --delay 5 --fork"
     And the exit status should be 0
 
   Scenario: Disable in a enabled mercurial repo

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,7 +15,7 @@ Before do
 
   # prevent launchy from opening gifs in tests
   set_env 'LAUNCHY_DRY_RUN', 'true'
-  set_env 'LOLCOMMITS_CAPTURER', 'CaptureFake'
+  set_env 'LOLCOMMITS_CAPTURER', 'Lolcommits::CaptureFake'
 
   author_name  = 'Testy McTesterson'
   author_email = 'testy@tester.com'

--- a/lib/lolcommits/backends/git_info.rb
+++ b/lib/lolcommits/backends/git_info.rb
@@ -1,7 +1,6 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
   class GitInfo < VCSInfo
-    include Methadone::CLILogging
     attr_accessor :sha, :message, :repo_internal_path, :repo, :url,
                   :author_name, :author_email, :branch
 

--- a/lib/lolcommits/backends/installation_git.rb
+++ b/lib/lolcommits/backends/installation_git.rb
@@ -10,12 +10,7 @@ module Lolcommits
     #
     # IF --ENABLE, DO ENABLE
     #
-    def self.do_enable
-      unless File.directory?('.git')
-        fatal "You don't appear to be in the base directory of a git project."
-        exit 1
-      end
-
+    def self.do_enable(capture_args = '')
       # its possible a hooks dir doesnt exist, so create it if so
       Dir.mkdir(HOOK_DIR) unless File.directory?(HOOK_DIR)
 
@@ -39,7 +34,7 @@ module Lolcommits
 
       File.open(HOOK_PATH, add_shebang ? 'w' : 'a') do |f|
         f.write("#!/bin/sh\n") if add_shebang
-        f.write(hook_script)
+        f.write(hook_script(capture_args))
       end
 
       FileUtils.chmod 0o755, HOOK_PATH
@@ -63,7 +58,7 @@ module Lolcommits
       end
     end
 
-    def self.hook_script
+    def self.hook_script(capture_args = '')
       ruby_path     = Lolcommits::Platform.command_which('ruby', true)
       imagick_path  = Lolcommits::Platform.command_which('identify', true)
 
@@ -74,13 +69,12 @@ module Lolcommits
         hook_export   = "export PATH=\"#{ruby_path}:#{imagick_path}:$PATH\"\n"
       end
 
-      capture_cmd   = 'lolcommits --capture'
-      capture_args  = " #{ARGV[1..-1].join(' ')}" if ARGV.length > 1
+      capture_cmd = 'lolcommits --capture'
 
       <<-EOS
 ### lolcommits hook (begin) ###
 if [ ! -d "$GIT_DIR/rebase-merge" ]; then
-#{locale_export}#{hook_export}#{capture_cmd}#{capture_args}
+#{locale_export}#{hook_export}#{capture_cmd} #{capture_args}
 fi
 ###  lolcommits hook (end)  ###
 EOS

--- a/lib/lolcommits/backends/installation_mercurial.rb
+++ b/lib/lolcommits/backends/installation_mercurial.rb
@@ -10,12 +10,7 @@ module Lolcommits
     #
     # IF --ENABLE, DO ENABLE
     #
-    def self.do_enable
-      unless File.directory?('.hg')
-        fatal "You don't appear to be in the base directory of a mercurial project."
-        exit 1
-      end
-
+    def self.do_enable(capture_args = '')
       if lolcommits_hook_exists?
         # clear away any existing lolcommits hook
         remove_existing_hook!
@@ -23,7 +18,7 @@ module Lolcommits
 
       config = repository.config
       HOOK_OPERATIONS.each do |op|
-        config.add_setting(HOOK_SECTION, "post-#{op}.lolcommits", hook_script)
+        config.add_setting(HOOK_SECTION, "post-#{op}.lolcommits", hook_script(capture_args))
       end
       config.path
     end
@@ -43,7 +38,7 @@ module Lolcommits
       end
     end
 
-    def self.hook_script
+    def self.hook_script(capture_args = '')
       ruby_path     = Lolcommits::Platform.command_which('ruby', true)
       imagick_path  = Lolcommits::Platform.command_which('identify', true)
       capture_cmd   = 'lolcommits --capture'
@@ -56,7 +51,6 @@ module Lolcommits
         capture_cmd = "#{locale_export} #{hook_export} #{capture_cmd}"
       end
 
-      capture_args = ARGV[1..-1].join(' ') if ARGV.length > 1
       "#{capture_cmd} #{capture_args}"
     end
 

--- a/lib/lolcommits/backends/mercurial_info.rb
+++ b/lib/lolcommits/backends/mercurial_info.rb
@@ -1,7 +1,6 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
   class MercurialInfo < VCSInfo
-    include Methadone::CLILogging
     attr_accessor :sha, :message, :repo_internal_path, :repo, :url,
                   :author_name, :author_email, :branch
 

--- a/lib/lolcommits/capturer.rb
+++ b/lib/lolcommits/capturer.rb
@@ -1,8 +1,6 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
   class Capturer
-    include Methadone::CLILogging
-
     attr_accessor :capture_device, :capture_delay, :snapshot_location,
                   :video_location, :frames_location, :animated_duration
 

--- a/lib/lolcommits/cli.rb
+++ b/lib/lolcommits/cli.rb
@@ -1,0 +1,4 @@
+require 'lolcommits/cli/fatals'
+require 'lolcommits/cli/launcher'
+require 'lolcommits/cli/process_runner'
+require 'lolcommits/cli/timelapse_gif'

--- a/lib/lolcommits/cli/fatals.rb
+++ b/lib/lolcommits/cli/fatals.rb
@@ -7,7 +7,6 @@ module Lolcommits
     # Helper methods for failing on error conditions in the lolcommits CLI.
     module Fatals
       include Lolcommits
-      include Methadone::CLILogging
 
       # Check for platform related conditions that could prevent lolcommits from
       # working properly.

--- a/lib/lolcommits/cli/timelapse_gif.rb
+++ b/lib/lolcommits/cli/timelapse_gif.rb
@@ -15,8 +15,6 @@ module Lolcommits
       # Runs the history timeline animator task thingy
       # param args [String] the arg passed to the gif command on CLI (optional)
       def run(args = nil)
-        Fatals.die_if_not_vcs_repo!
-
         case args
         when 'today'
           lolimages = @configuration.jpg_images_today

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -67,8 +67,8 @@ module Lolcommits
       File.join(loldir, 'tmp_frames')
     end
 
-    def puts_plugins
-      puts "Available plugins: #{Lolcommits::Runner.plugins.map(&:name).join(', ')}"
+    def plugins_list
+      "Available plugins: \n * #{Lolcommits::Runner.plugins.map(&:name).join("\n * ")}"
     end
 
     def ask_for_plugin_name
@@ -87,6 +87,7 @@ module Lolcommits
     end
 
     def do_configure!(plugin_name)
+      $stdout.sync = true
       plugin_name = ask_for_plugin_name if plugin_name.to_s.strip.empty?
 
       plugin = find_plugin(plugin_name)

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -72,7 +72,7 @@ module Lolcommits
     end
 
     def ask_for_plugin_name
-      puts_plugins
+      puts plugins_list
       print 'Name of plugin to configure: '
       STDIN.gets.strip
     end
@@ -83,7 +83,7 @@ module Lolcommits
       end
 
       puts "Unable to find plugin: '#{plugin_name}'"
-      puts_plugins
+      puts plugins_list
     end
 
     def do_configure!(plugin_name)

--- a/lib/lolcommits/installation.rb
+++ b/lib/lolcommits/installation.rb
@@ -18,8 +18,9 @@ module Lolcommits
     #
     # IF --ENABLE, DO ENABLE
     #
-    def self.do_enable
-      path = backend.do_enable
+    def self.do_enable(options = {})
+      capture_args = extract_capture_args(options)
+      path         = backend.do_enable(capture_args)
 
       info 'installed lolcommit hook to:'
       info "  -> #{File.expand_path(path)}"
@@ -33,6 +34,21 @@ module Lolcommits
     #
     def self.do_disable
       backend.do_disable
+    end
+
+    # Extract any command line capture args from the parsed options hash, will
+    # be appended to the capture command within the commit hook script
+    #
+    # @return [String]
+    def self.extract_capture_args(options)
+      options.map do |k, v|
+        next unless %w(device animate delay stealth fork).include?(k)
+        if k == 'device'
+          "--device '#{v}'"
+        else
+          "--#{k}#{v == true ? '' : " #{v}"}"
+        end
+      end.compact.join(' ')
     end
   end
 end

--- a/lib/lolcommits/plugin.rb
+++ b/lib/lolcommits/plugin.rb
@@ -1,8 +1,6 @@
 # -*- encoding : utf-8 -*-
 module Lolcommits
   class Plugin
-    include Methadone::CLILogging
-
     attr_accessor :runner, :options
 
     def initialize(runner)

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -40,12 +40,12 @@ module Lolcommits
       string.upcase! if config_option(type, :uppercase)
 
       image.combine_options do |c|
-        c.strokewidth runner.animate? ? '1' : '2'
+        c.strokewidth runner.capture_animated? ? '1' : '2'
         c.interline_spacing(-(config_option(type, :size) / 5))
         c.stroke config_option(type, :stroke_color)
         c.fill config_option(type, :color)
         c.gravity transformed_position
-        c.pointsize runner.animate? ? (config_option(type, :size) / 2) : config_option(type, :size)
+        c.pointsize runner.capture_animated? ? (config_option(type, :size) / 2) : config_option(type, :size)
         c.font config_option(type, :font)
         c.annotate annotate_location, string
       end

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -7,7 +7,6 @@ module Lolcommits
                   :sha, :snapshot_loc, :main_image, :config, :vcs_info,
                   :capture_animate
 
-    include Methadone::CLILogging
 
     def initialize(attributes = {})
       attributes.each do |attr, val|
@@ -96,46 +95,39 @@ module Lolcommits
       capturer.capture
     end
 
-    def animate?
-      capture_animate && (capture_animate.to_i > 0)
+    def capture_animated?
+      capture_animate > 0
     end
 
     private
 
-    # def capturer_class
-    #   capturer_module = 'Lolcommits'
-    #   Object.const_get(capturer_module).const_get(Platform.capturer_class(animate?))
-    # end
-
     def image_file_type
-      animate? ? 'gif' : 'jpg'
+      capture_animated? ? 'gif' : 'jpg'
     end
-  end
 
-  protected
-
-  def resize_snapshot!
-    debug 'Runner: resizing snapshot'
-    image = MiniMagick::Image.open(snapshot_loc)
-    if image[:width] > 640 || image[:height] > 480
-      # this is ghetto resize-to-fill
-      image.combine_options do |c|
-        c.resize '640x480^'
-        c.gravity 'center'
-        c.extent '640x480'
+    def resize_snapshot!
+      debug 'Runner: resizing snapshot'
+      image = MiniMagick::Image.open(snapshot_loc)
+      if image[:width] > 640 || image[:height] > 480
+        # this is ghetto resize-to-fill
+        image.combine_options do |c|
+          c.resize '640x480^'
+          c.gravity 'center'
+          c.extent '640x480'
+        end
+        debug "Runner: writing resized image to #{snapshot_loc}"
+        image.write snapshot_loc
       end
-      debug "Runner: writing resized image to #{snapshot_loc}"
-      image.write snapshot_loc
+      debug "Runner: copying resized image to #{main_image}"
+      FileUtils.cp(snapshot_loc, main_image)
     end
-    debug "Runner: copying resized image to #{main_image}"
-    FileUtils.cp(snapshot_loc, main_image)
-  end
 
-  def cleanup!
-    debug 'Runner: running cleanup'
-    # clean up the captured image and any other raw assets
-    FileUtils.rm(snapshot_loc)
-    FileUtils.rm_f(config.video_loc)
-    FileUtils.rm_rf(config.frames_loc)
+    def cleanup!
+      debug 'Runner: running cleanup'
+      # clean up the captured image and any other raw assets
+      FileUtils.rm(snapshot_loc)
+      FileUtils.rm_f(config.video_loc)
+      FileUtils.rm_rf(config.frames_loc)
+    end
   end
 end

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -7,7 +7,6 @@ module Lolcommits
                   :sha, :snapshot_loc, :main_image, :config, :vcs_info,
                   :capture_animate
 
-
     def initialize(attributes = {})
       attributes.each do |attr, val|
         send("#{attr}=", val)

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -83,7 +83,7 @@ module Lolcommits
       self.snapshot_loc = config.raw_image(image_file_type)
       self.main_image   = config.main_image(sha, image_file_type)
 
-      capturer = Platform.capturer_class(animate?).new(
+      capturer = Platform.capturer_class(capture_animated?).new(
         capture_device: capture_device,
         capture_delay: capture_delay,
         snapshot_location: snapshot_loc,

--- a/lib/lolcommits/vcs_info.rb
+++ b/lib/lolcommits/vcs_info.rb
@@ -2,7 +2,6 @@
 module Lolcommits
   # base class ala plugin.rb
   class VCSInfo
-    include Methadone::CLILogging
     attr_accessor :sha, :message, :repo_internal_path, :repo, :url,
                   :author_name, :author_email, :branch
 

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |s|
 
   # core
   s.add_runtime_dependency('methadone', '~> 1.9.3')
-  s.add_runtime_dependency('choice', '~> 0.2.0')
   s.add_runtime_dependency('mercurial-ruby', '~> 0.7.12')
   s.add_runtime_dependency('mini_magick', '~> 4.6.0')
   s.add_runtime_dependency('launchy', '~> 2.4.3')

--- a/test/lolcommits_test.rb
+++ b/test/lolcommits_test.rb
@@ -11,6 +11,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'lolcommits'
 
 include Lolcommits
+include Methadone::CLILogging
 
 class LolTest < MiniTest::Test
   #


### PR DESCRIPTION
This PR removes the Choice gem, and switches to using Methadone to handle command arguments directly. The syntax for arguments remain mostly unchanged (except some cases where argument options are required or optional)  So the new`help` output looks like this;

```
Usage: lolcommits [options]

git-based selfies for software developers (https://lolcommits.github.io)

v0.9.0

Options:
    -h, --help                       Show command line help
        --version                    Show help/version info
        --test                       run in test mode
        --debug                      show debugging info
        --show-config                show configuration file
        --devices                    list available capture devices (mac only)
        --plugins                    list all available plugins
        --config                     configure a plugin
    -p, --plugin {name}              plugin name to use with --config
    -c, --capture                    capture lolcommit based on last git commit
    -e, --enable                     install lolcommits for this repo
    -d, --disable                    uninstall lolcommits for this repo
    -l, --last                       view the most recent lolcommit
    -b, --browse                     browse this repo's lolcommits
        --timelapse                  generate animated timelapse gif from captured images
        --period {today}             period to use for the timelapse gif (today or all)
        --device {name}              device name to capture from (mac/linux only)
    -a, --animate {seconds}          enable animated gif captures with duration
    -w, --delay {seconds}            delay before taking a snapshot
        --stealth                    capture image in stealth mode (no output)
        --fork                       fork capturing process to the background
    -s, --sha {string}               pass commit sha manually (--test mode only)
    -m, --msg {string}               pass commit message manually (--test mode only)
```

The README and tests have been updated to reflect new command line arg format (I will also update  the wiki). Duplication of `include Methadone::CLILogging` also tidied up.

This PR closes #259 