### PR TITLE
Remove twitter gem, fixes Ruby 2.4 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
  - 2.2.4
  - 2.3.0
  - 2.3.3
+ - 2.4.0
  - ruby-head
 
 before_install:

--- a/lib/lolcommits/plugins/lol_twitter.rb
+++ b/lib/lolcommits/plugins/lol_twitter.rb
@@ -10,7 +10,7 @@ module Lolcommits
     TWITTER_API_ENDPOINT         = 'https://api.twitter.com'.freeze
     TWITTER_CONSUMER_KEY         = 'qc096dJJCxIiqDNUqEsqQ'.freeze
     TWITTER_CONSUMER_SECRET      = 'rvjNdtwSr1H0TvBvjpk6c4bvrNydHmmbvv7gXZQI'.freeze
-    TWITTER_RESERVED_MEDIA_CHARS = 23
+    TWITTER_RESERVED_MEDIA_CHARS = 24
     TWITTER_RETRIES              = 2
     TWITTER_PIN_REGEX            = /^\d{4,}$/ # 4 or more digits
     DEFAULT_SUFFIX               = '#lolcommits'.freeze
@@ -33,6 +33,8 @@ module Lolcommits
     end
 
     def post_url
+      # TODO: this endpoint is deprecated, use the new approach instead
+      # https://dev.twitter.com/rest/reference/post/statuses/update_with_mediath_media
       @post_url ||= TWITTER_API_ENDPOINT + '/1.1/statuses/update_with_media.json'
     end
 

--- a/lib/lolcommits/plugins/lol_twitter.rb
+++ b/lib/lolcommits/plugins/lol_twitter.rb
@@ -1,16 +1,19 @@
 # -*- encoding : utf-8 -*-
 require 'yaml'
 require 'oauth'
-require 'twitter'
+require 'simple_oauth'
+require 'rest_client'
+require 'addressable/uri'
 
 module Lolcommits
   class LolTwitter < Plugin
-    TWITTER_API_ENDPOINT    = 'https://api.twitter.com'.freeze
-    TWITTER_CONSUMER_KEY    = 'qc096dJJCxIiqDNUqEsqQ'.freeze
-    TWITTER_CONSUMER_SECRET = 'rvjNdtwSr1H0TvBvjpk6c4bvrNydHmmbvv7gXZQI'.freeze
-    TWITTER_RETRIES         = 2
-    TWITTER_PIN_REGEX       = /^\d{4,}$/ # 4 or more digits
-    DEFAULT_SUFFIX          = '#lolcommits'.freeze
+    TWITTER_API_ENDPOINT         = 'https://api.twitter.com'.freeze
+    TWITTER_CONSUMER_KEY         = 'qc096dJJCxIiqDNUqEsqQ'.freeze
+    TWITTER_CONSUMER_SECRET      = 'rvjNdtwSr1H0TvBvjpk6c4bvrNydHmmbvv7gXZQI'.freeze
+    TWITTER_RESERVED_MEDIA_CHARS = 23
+    TWITTER_RETRIES              = 2
+    TWITTER_PIN_REGEX            = /^\d{4,}$/ # 4 or more digits
+    DEFAULT_SUFFIX               = '#lolcommits'.freeze
 
     def run_postcapture
       return unless valid_configuration?
@@ -21,15 +24,26 @@ module Lolcommits
         attempts += 1
         puts "Tweeting: #{tweet}"
         debug "--> Tweeting! (attempt: #{attempts}, tweet length: #{tweet.length} chars)"
-        if client.update_with_media(tweet, File.open(runner.main_image, 'r'))
-          puts "\t--> Tweet Sent!"
-        end
-      rescue Twitter::Error::ServerError,
-             Twitter::Error::ClientError => e
+        post_tweet(tweet, File.open(runner.main_image, 'r'))
+      rescue StandardError => e
         debug "Tweet FAILED! #{e.class} - #{e.message}"
         retry if attempts < TWITTER_RETRIES
         puts "ERROR: Tweet FAILED! (after #{attempts} attempts) - #{e.message}"
       end
+    end
+
+    def post_url
+      @post_url ||= TWITTER_API_ENDPOINT + '/1.1/statuses/update_with_media.json'
+    end
+
+    def post_tweet(status, media)
+      RestClient.post(
+        post_url,
+        {
+          'media[]' => media,
+          'status'  => status
+        }, Authorization: oauth_header
+      )
     end
 
     def build_tweet(commit_message)
@@ -113,13 +127,18 @@ module Lolcommits
         configuration['secret']
     end
 
-    def client
-      @client ||= Twitter::REST::Client.new do |config|
-        config.consumer_key        = TWITTER_CONSUMER_KEY
-        config.consumer_secret     = TWITTER_CONSUMER_SECRET
-        config.access_token        = configuration['access_token']
-        config.access_token_secret = configuration['secret']
-      end
+    def oauth_header
+      uri = Addressable::URI.parse(post_url)
+      SimpleOAuth::Header.new(:post, uri, {}, oauth_credentials)
+    end
+
+    def oauth_credentials
+      {
+        consumer_key: TWITTER_CONSUMER_KEY,
+        consumer_secret: TWITTER_CONSUMER_SECRET,
+        token: configuration['access_token'],
+        token_secret: configuration['secret']
+      }
     end
 
     def oauth_consumer
@@ -141,7 +160,7 @@ module Lolcommits
     end
 
     def max_tweet_size
-      139 - client.configuration.characters_reserved_per_media
+      139 - TWITTER_RESERVED_MEDIA_CHARS
     end
 
     def self.name

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('net-http-persistent', '=2.9.4') # ~> 3+ requires Ruby 2.1
 
   # core
-  s.add_runtime_dependency('methadone', '~> 1.9.4')
+  s.add_runtime_dependency('methadone', '~> 1.9.5')
   s.add_runtime_dependency('mercurial-ruby', '~> 0.7.12')
   s.add_runtime_dependency('mini_magick', '~> 4.6.0')
   s.add_runtime_dependency('launchy', '~> 2.4.3')
@@ -47,14 +47,14 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('tumblr_client', '~> 0.8.5')  # tumblr
 
   # development gems
-  s.add_development_dependency('rdoc', '~> 5.0.0')
-
-  # testing gems
+  s.add_development_dependency('rdoc')
   s.add_development_dependency('pry')
-  s.add_development_dependency('rubocop', '~> 0.46.0')
-  s.add_development_dependency('travis', '~> 1.8.5')
-  s.add_development_dependency('minitest', '~> 5.10.1')
-  s.add_development_dependency('coveralls', '~> 0.8.17')
-  s.add_development_dependency('ffaker', '~> 2.3.0')
-  s.add_development_dependency('cucumber', '~> 2.4.0')
+
+  # testing gems (latest versions)
+  s.add_development_dependency('rubocop')
+  s.add_development_dependency('travis')
+  s.add_development_dependency('minitest')
+  s.add_development_dependency('coveralls')
+  s.add_development_dependency('ffaker')
+  s.add_development_dependency('cucumber')
 end

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -31,11 +31,10 @@ Gem::Specification.new do |s|
   # hold back upgrading (and why)
   s.add_development_dependency('aruba', '=0.6.2')  # upgrading requires a lot of test code changes
   s.add_development_dependency('rake', '=10.5.0')  # ~> 11+ introduces lots of warnings from other deps
-  s.add_runtime_dependency('twitter', '~> 5.17.0') # twitter 6+ requires higher faraday
   s.add_runtime_dependency('net-http-persistent', '=2.9.4') # ~> 3+ requires Ruby 2.1
 
   # core
-  s.add_runtime_dependency('methadone', '~> 1.9.3')
+  s.add_runtime_dependency('methadone', '~> 1.9.4')
   s.add_runtime_dependency('mercurial-ruby', '~> 0.7.12')
   s.add_runtime_dependency('mini_magick', '~> 4.6.0')
   s.add_runtime_dependency('launchy', '~> 2.4.3')
@@ -51,6 +50,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rdoc', '~> 5.0.0')
 
   # testing gems
+  s.add_development_dependency('pry')
   s.add_development_dependency('rubocop', '~> 0.46.0')
   s.add_development_dependency('travis', '~> 1.8.5')
   s.add_development_dependency('minitest', '~> 5.10.1')


### PR DESCRIPTION
This PR achieves Ruby 2.4 compatibility (fixes #327) by;

* Ditching the Twitter gem, we had been forced to use the older 5.17.0 (which fails on 2.4 due to an older json gem breaking compilation) - and upgrading to 6+ means we have faraday gem dependency issues with other gems in our dep chain.  Now we use oauth and the rest-client libraries directly to post tweets.

* Updates methadone to 1.9.5 (1.9.4 broke for various reasons on Ruby 2.4, which [I fixed](https://github.com/davetron5000/methadone/pull/111)) 

---

I also took the opportunity to add pry, and remove gem versions from our development and testing gems, since we do always want to be using the latest versions for these.

Will merge and release a new gem for this when Travis is green.


