### PR TITLE
remove Ruby 1.9 utf-8 magic comments

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-# -*- encoding: utf-8 -*-
 
 begin
   require 'lolcommits'

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'fileutils'
 require 'aruba/api'
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'aruba/cucumber'
 require 'methadone/cucumber'
 require 'open3'

--- a/features/support/path_helpers.rb
+++ b/features/support/path_helpers.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'fileutils'
 require 'aruba/api'
 require 'lolcommits/platform'

--- a/lib/core_ext/class.rb
+++ b/lib/core_ext/class.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 class Class
   def subclasses
     result = []

--- a/lib/core_ext/mini_magick/utilities.rb
+++ b/lib/core_ext/mini_magick/utilities.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 # To maintain MiniMagick compatibility on Windows for v3.8.1 we need this patch
 # If/when we upgrade MiniMagick to 4.2+ this patch can be removed
 # We are locked at v3.8.1 since MiniMagick 4+ dropped support for Ruby 1.8.7

--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 $LOAD_PATH.unshift File.expand_path('.')
 
 require 'core_ext/class'

--- a/lib/lolcommits/backends/git_info.rb
+++ b/lib/lolcommits/backends/git_info.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class GitInfo < VCSInfo
     attr_accessor :sha, :message, :repo_internal_path, :repo, :url,

--- a/lib/lolcommits/backends/installation_git.rb
+++ b/lib/lolcommits/backends/installation_git.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   #
   # Methods to handle enabling and disabling of lolcommits

--- a/lib/lolcommits/backends/installation_mercurial.rb
+++ b/lib/lolcommits/backends/installation_mercurial.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   #
   # Methods to handle enabling and disabling of lolcommits

--- a/lib/lolcommits/backends/mercurial_info.rb
+++ b/lib/lolcommits/backends/mercurial_info.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class MercurialInfo < VCSInfo
     attr_accessor :sha, :message, :repo_internal_path, :repo, :url,

--- a/lib/lolcommits/capturer.rb
+++ b/lib/lolcommits/capturer.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class Capturer
     attr_accessor :capture_device, :capture_delay, :snapshot_location,

--- a/lib/lolcommits/capturer/capture_cygwin.rb
+++ b/lib/lolcommits/capturer/capture_cygwin.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class CaptureCygwin < Capturer
     def capture

--- a/lib/lolcommits/capturer/capture_fake.rb
+++ b/lib/lolcommits/capturer/capture_fake.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class CaptureFake < Capturer
     def capture

--- a/lib/lolcommits/capturer/capture_linux.rb
+++ b/lib/lolcommits/capturer/capture_linux.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class CaptureLinux < Capturer
     MPLAYER_FPS = 25

--- a/lib/lolcommits/capturer/capture_linux_animated.rb
+++ b/lib/lolcommits/capturer/capture_linux_animated.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class CaptureLinuxAnimated < Capturer
     def capture

--- a/lib/lolcommits/capturer/capture_mac.rb
+++ b/lib/lolcommits/capturer/capture_mac.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class CaptureMac < Capturer
     def capture_device_string

--- a/lib/lolcommits/capturer/capture_mac_animated.rb
+++ b/lib/lolcommits/capturer/capture_mac_animated.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class CaptureMacAnimated < Capturer
     def capture

--- a/lib/lolcommits/capturer/capture_windows.rb
+++ b/lib/lolcommits/capturer/capture_windows.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class CaptureWindows < Capturer
     def capture

--- a/lib/lolcommits/cli/fatals.rb
+++ b/lib/lolcommits/cli/fatals.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 require 'lolcommits/platform'
 require 'methadone'
 

--- a/lib/lolcommits/cli/launcher.rb
+++ b/lib/lolcommits/cli/launcher.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 require 'launchy'
 
 module Lolcommits

--- a/lib/lolcommits/cli/process_runner.rb
+++ b/lib/lolcommits/cli/process_runner.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 module Lolcommits
   module CLI
     # Helper class for forking lolcommits process to the background (or not).

--- a/lib/lolcommits/cli/timelapse_gif.rb
+++ b/lib/lolcommits/cli/timelapse_gif.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 require 'lolcommits/cli/fatals'
 
 require 'mini_magick'

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -1,5 +1,3 @@
-# -*- encoding : utf-8 -*-
-
 module Lolcommits
   class Configuration
     LOLCOMMITS_BASE = ENV['LOLCOMMITS_DIR'] || File.join(ENV['HOME'], '.lolcommits')

--- a/lib/lolcommits/installation.rb
+++ b/lib/lolcommits/installation.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   #
   # Methods to handle enabling and disabling of lolcommits

--- a/lib/lolcommits/platform.rb
+++ b/lib/lolcommits/platform.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'mini_magick'
 require 'rbconfig'
 

--- a/lib/lolcommits/plugin.rb
+++ b/lib/lolcommits/plugin.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class Plugin
     attr_accessor :runner, :options

--- a/lib/lolcommits/plugins/dot_com.rb
+++ b/lib/lolcommits/plugins/dot_com.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'httmultiparty'
 
 module Lolcommits

--- a/lib/lolcommits/plugins/lol_flowdock.rb
+++ b/lib/lolcommits/plugins/lol_flowdock.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'rest_client'
 
 module Lolcommits

--- a/lib/lolcommits/plugins/lol_hipchat.rb
+++ b/lib/lolcommits/plugins/lol_hipchat.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class LolHipchat < Plugin
     def configure_options!

--- a/lib/lolcommits/plugins/lol_protonet.rb
+++ b/lib/lolcommits/plugins/lol_protonet.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'rest_client'
 
 module Lolcommits

--- a/lib/lolcommits/plugins/lol_slack.rb
+++ b/lib/lolcommits/plugins/lol_slack.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'rest_client'
 
 module Lolcommits

--- a/lib/lolcommits/plugins/lol_tumblr.rb
+++ b/lib/lolcommits/plugins/lol_tumblr.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'yaml'
 require 'oauth'
 require 'webrick'

--- a/lib/lolcommits/plugins/lol_twitter.rb
+++ b/lib/lolcommits/plugins/lol_twitter.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'yaml'
 require 'oauth'
 require 'simple_oauth'

--- a/lib/lolcommits/plugins/lol_yammer.rb
+++ b/lib/lolcommits/plugins/lol_yammer.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'yammer'
 require 'rest_client'
 

--- a/lib/lolcommits/plugins/lolsrv.rb
+++ b/lib/lolcommits/plugins/lolsrv.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'rest_client'
 require 'pp'
 require 'json'

--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   class Loltext < Plugin
     DEFAULT_FONT_PATH = File.join(Configuration::LOLCOMMITS_ROOT, 'vendor', 'fonts', 'Impact.ttf')

--- a/lib/lolcommits/plugins/term_output.rb
+++ b/lib/lolcommits/plugins/term_output.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'base64'
 
 module Lolcommits

--- a/lib/lolcommits/plugins/tranzlate.rb
+++ b/lib/lolcommits/plugins/tranzlate.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 # Adapted and expanded from https://github.com/rwtnorton/moar-lolspeak
 # which was largely taken from an old Perl script and is sadly is not
 # available via rubygems

--- a/lib/lolcommits/plugins/uploldz.rb
+++ b/lib/lolcommits/plugins/uploldz.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'rest_client'
 require 'base64'
 

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'lolcommits/platform'
 
 module Lolcommits

--- a/lib/lolcommits/vcs_info.rb
+++ b/lib/lolcommits/vcs_info.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   # base class ala plugin.rb
   class VCSInfo

--- a/lib/lolcommits/version.rb
+++ b/lib/lolcommits/version.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 module Lolcommits
   VERSION = '0.9.2'.freeze
 end

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'lolcommits/version'

--- a/test/lolcommits_test.rb
+++ b/test/lolcommits_test.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'coveralls'
 Coveralls.wear!
 

--- a/test/plugins_test.rb
+++ b/test/plugins_test.rb
@@ -1,4 +1,3 @@
-# -*- encoding : utf-8 -*-
 require 'coveralls'
 Coveralls.wear!
 


### PR DESCRIPTION
Removes all the Ruby 1.9 magic UTF-8 encoding comments, since we're now officially on Ruby 2.0+