### PR TITLE
Add North gravity for imagemagick

### DIFF
--- a/lib/lolcommits/plugins/loltext.rb
+++ b/lib/lolcommits/plugins/loltext.rb
@@ -151,6 +151,8 @@ module Lolcommits
         'SouthWest'
       when 'C'
         'Center'
+      when 'N'
+        'North'
       when 'S'
         'South'
       end


### PR DESCRIPTION
Doing this to allow loltext to be centred at the top of the image.

As listed in the imagemagick CLI docs - https://www.imagemagick.org/script/command-line-options.php#gravity