### PR TITLE
make it possible to short-circuit the capture command via LOLCOMMITS_CAPTURE_DISABLED=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ via environment variables like so;
   process, speedily returning you to your terminal)
 * `LOLCOMMITS_STEALTH` disable notification messages at commit time
 * `LOLCOMMITS_DIR` set the output directory used for all repositories (defaults to ~/.lolcommits)
+* `LOLCOMMITS_CAPTURE_DISABLED` short-cirtcuits the capture command if set to `1`
 
 Or they can be set with these arguments to the capture command (located in your
 repository's `.git/hooks/post-commit` file).

--- a/lib/lolcommits/backends/installation_git.rb
+++ b/lib/lolcommits/backends/installation_git.rb
@@ -72,7 +72,7 @@ module Lolcommits
 
       <<-EOS
 ### lolcommits hook (begin) ###
-if [ ! -d "$GIT_DIR/rebase-merge" ]; then
+if [ ! -d "$GIT_DIR/rebase-merge" ] && [ "$LOLCOMMITS_CAPTURE_DISABLED" != "1" ]; then
 #{locale_export}#{hook_export}#{capture_cmd} #{capture_args}
 fi
 ###  lolcommits hook (end)  ###


### PR DESCRIPTION
I tend to do a lot of `WIP` commits via a `wip` git alias (I'm not interested in capturing these commits). I thought it'd be nice if I could disable capturing by prepending `git commit` with `LOLCOMMITS_CAPTURE_DISABLED=1` in my alias.