### PR TITLE
Refactor plugin manager, runner and config

### DIFF
--- a/bin/lolcommits
+++ b/bin/lolcommits
@@ -36,13 +36,13 @@ class App
         debug 'Outputting at DEBUG verbosity'
       end
 
-      # TODO: move to a better place
-      load_plugins
+      plugin_manager = PluginManager.init
+      config         = Configuration.new(plugin_manager, test_mode: options[:test])
 
       if options[:'show-config']
-        puts configuration
+        puts config
       elsif options[:plugins]
-        puts configuration.plugins_list
+        config.list_plugins
       elsif options[:devices]
         puts Platform.device_list
         puts device_list_help
@@ -59,15 +59,15 @@ class App
         end
 
         if options[:last]
-          show_last_lolimage
+          show_last_lolimage(config.loldir)
         elsif options[:browse]
-          Launcher.open_folder(configuration.loldir)
+          Launcher.open_folder(config.loldir)
         elsif options[:timelapse]
-          TimelapseGif.new(configuration).run(options[:period])
+          TimelapseGif.new(config).run(options[:period])
         elsif options[:config]
-          configuration.do_configure!(options[:plugin])
+          config.do_configure!(options[:plugin])
         elsif options[:capture]
-          capture_lolcommit
+          capture_lolcommit(config)
         end
       end
     end
@@ -75,7 +75,7 @@ class App
 
   on('--test', 'run in test mode')
   on('--debug', 'show debugging info')
-  on('--show-config', 'show configuration file')
+  on('--show-config', 'show config file')
   on('--devices', 'list available capture devices (mac only)')
   on('--plugins', 'list all available plugins')
   on('--config', 'configure a plugin')
@@ -109,34 +109,17 @@ class App
       'Or:  lolcommits --help'
   end
 
-  # Gets a configuration object.  If running in test mode will override the
-  # LOLDIR for the configuration.
-  #
-  # @return [Lolcommits::Configuration]
-  def self.configuration
-    if options[:test]
-      Configuration.new(loldir: Configuration.loldir_for('test'))
-    else
-      Configuration.new
-    end
-  end
-
   def self.debug_enabled?
     options[:debug] || ENV['LOLCOMMITS_DEBUG'] || false
-  end
-
-  def self.load_plugins
-    pm = Lolcommits::PluginManager.new
-    pm.locate_plugins
-    pm.load_plugins
   end
 
   def self.device_list_help
     'Specify a device with --device "{device name}" or set the LOLCOMMITS_DEVICE env variable'
   end
 
-  def self.show_last_lolimage
-    lolimage = configuration.most_recent
+  def self.show_last_lolimage(loldir)
+    lolimage = Dir.glob(File.join(loldir, '*.{jpg,gif}')).max_by { |f| File.mtime(f) }
+
     if lolimage.nil?
       warn 'No lolcommits have been captured for this repository yet.'
       exit 1
@@ -150,7 +133,7 @@ class App
     result
   end
 
-  def self.capture_lolcommit
+  def self.capture_lolcommit(config)
     should_we_fork  = options[:fork] || ENV['LOLCOMMITS_FORK'] || false
     capture_stealth = options[:stealth] || ENV['LOLCOMMITS_STEALTH'] || false
     capture_delay   = (options[:delay] || ENV['LOLCOMMITS_DELAY']).to_i
@@ -160,10 +143,10 @@ class App
       capture_stealth: capture_stealth,
       capture_device: capture_device,
       capture_animate: capture_animate,
-      config: configuration
+      config: config
     }
 
-    process_runner = ProcessRunner.new(configuration)
+    process_runner = ProcessRunner.new(config)
     process_runner.fork_me?(should_we_fork) do
       if options[:test]
         info '*** Capturing in test mode.'

--- a/lib/lolcommits/plugin/base.rb
+++ b/lib/lolcommits/plugin/base.rb
@@ -100,10 +100,16 @@ module Lolcommits
         'plugin'
       end
 
-      # a plugin requests to be run by the runner in one of these positions
-      # valid options are [:precapture, :postcapture]
+      # Returns position(s) of when a plugin should run during the capture
+      # process.
+      #
+      # Defines when the plugin will execute in the capture process. This must
+      # be defined, if the method returns nil, or [] the plugin will never run.
+      #
+      # @return [Array] the position(s) (:precapture and/or :postcapture)
+      #
       def self.runner_order
-        nil
+        []
       end
     end
   end

--- a/lib/lolcommits/plugin_manager.rb
+++ b/lib/lolcommits/plugin_manager.rb
@@ -19,7 +19,7 @@ module Lolcommits
     end
 
     def plugins_for(position)
-      plugin_klasses.select { |p| p.runner_order == position }
+      plugin_klasses.select { |p| Array(p.runner_order).include?(position) }
     end
 
     # @return [Lolcommits::Plugin] find first plugin matching name

--- a/lib/lolcommits/plugin_manager.rb
+++ b/lib/lolcommits/plugin_manager.rb
@@ -1,40 +1,62 @@
 module Lolcommits
   class PluginManager
-    GEM_NAME_PREFIX = /^lolcommits-plugin-/
+    GEM_NAME_PREFIX = /^lolcommits-/
+
+    def self.init
+      pm = new
+      pm.load_plugins
+      pm
+    end
 
     def initialize
       @plugins = []
     end
 
-    # @return [Array] find all installed and supported plugins, storing to
-    #   @plugins Array, and returns this array
-    def locate_plugins
-      gem_list.each do |gem|
-        next if gem.name !~ GEM_NAME_PREFIX
-        plugin_name = gem.name.split('-', 2).last
-        plugin = GemPlugin.new(plugin_name, gem.name, gem)
-
-        @plugins << plugin if plugin.supported? && !plugin_located?(plugin)
-      end
-      @plugins
-    end
-
-    # @return [Hash] A hash with all plugin names (minus the prefix) as
-    #   keys and Plugin objects as values
-    def plugins
-      h = {}
-      @plugins.each do |plugin|
-        h[plugin.name] = plugin
-      end
-      h
-    end
-
-    # require all plugins
+    # find and require all plugins
     def load_plugins
+      find_plugins
       @plugins.map(&:activate!)
     end
 
+    def plugins_for(position)
+      plugin_klasses.select { |p| p.runner_order == position }
+    end
+
+    # @return [Lolcommits::Plugin] find first plugin matching name
+    def find_by_name(name)
+      plugin_klasses.find { |plugin| plugin.name =~ /^#{name}/ }
+    end
+
+    def plugin_names
+      # TODO: when all plugins are gems, get names from GemPlugin with
+      #   @plugins.map(&:name)
+      plugin_klasses.map(&:name).sort
+    end
+
     private
+
+    # @return [Array] find all classes inheriting from Lolcommits::Plugin::Base
+    def plugin_klasses
+      # TODO: when all plugins are gems, change this to
+      #   @plugins.map(&:plugin_klass)
+      ObjectSpace.each_object(Class).select { |klass| klass < Lolcommits::Plugin::Base }
+    end
+
+    # @return [Array] find all installed and supported plugins, populate
+    #   @plugins array and return it
+    def find_plugins
+      find_gems.map do |gem|
+        plugin = GemPlugin.new(gem)
+        @plugins << plugin if plugin.supported? && !plugin_located?(plugin)
+      end
+
+      @plugins
+    end
+
+    # @return [Array] find all installed gems matching GEM_NAME_PREFIX
+    def find_gems
+      gem_list.select { |gem| gem.name =~ GEM_NAME_PREFIX }
+    end
 
     def plugin_located?(plugin)
       @plugins.any? { |existing| existing.gem_name == plugin.gem_name }


### PR DESCRIPTION
This PR refactors some of the code around the `PluginManager`, `GemPlugin` and `Configuration` classes.  Some cleanup in `bin/lolcommits` and I action a bunch of TODOs added in #332 

* `GEM_NAME_PREFIX` changed to `/^lolcommits-/` - to match the pry style 

I don't think there is a need to have the word 'plugin' in all the gem names, so our gem plugin names will be something like `lolcommits-twitter`, `lolcommits-txt`, `lolcommits-slack`etc.

* `PluginManager` now handles finding / listing plugin classes
* `Configuration` now takes a `PluginManager` and `loldir` as arguments
* `bin/lolcommits` tidied up to have init instances of config and plugin manager 
* `show_last_lolimage` moved out of the `Configuration` class
* `GemPlugin` now only requires a `gem_spec` arg (added future TODO's here for later)
* Plugins can now define both `precapture` and `postcapture` hooks (in the same Plugin class)
                                              
