### PR TITLE
Add LOLCOMMITS_CAPTURE_DISABLED

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ via environment variables like so;
 * `LOLCOMMITS_STEALTH` disable all notification messages when capturing
 * `LOLCOMMITS_DIR` set the output directory used for all repositories (defaults
   to ~/.lolcommits)
+* `LOLCOMMITS_CAPTURE_DISABLED` disables lolcommit capturing in the commit hook
+  (when set as 'true')
+
 
 Or they can be set with arguments to the capture command (located in your
 repository's `.git/hooks/post-commit` file).

--- a/lib/lolcommits/backends/installation_git.rb
+++ b/lib/lolcommits/backends/installation_git.rb
@@ -58,22 +58,26 @@ module Lolcommits
     end
 
     def self.hook_script(capture_args = '')
+      # TODO have this return a single line bash like mercurial install, and DRY
+      # this method (only different in git is the rebase-merge check which could
+      # be extracted
       ruby_path     = Lolcommits::Platform.command_which('ruby', true)
       imagick_path  = Lolcommits::Platform.command_which('identify', true)
+      capture_cmd   = 'lolcommits --capture'
 
       if Lolcommits::Platform.platform_windows?
-        hook_export = "set path \"#{ruby_path};#{imagick_path};%PATH%\"\n"
+        capture_cmd = 'if "%LOLCOMMITS_CAPTURE_DISABLED%"=="true" (exit)'
+        capture_cmd = "set path=#{ruby_path};#{imagick_path};%PATH%&&#{capture_cmd}"
       else
-        locale_export = "export LANG=\"#{ENV['LANG']}\"\n"
-        hook_export   = "export PATH=\"#{ruby_path}:#{imagick_path}:$PATH\"\n"
+        locale_export = "LANG=\"#{ENV['LANG']}\""
+        hook_export   = "PATH=\"#{ruby_path}:#{imagick_path}:$PATH\""
+        capture_cmd   = "#{locale_export} #{hook_export} #{capture_cmd}"
       end
-
-      capture_cmd = 'lolcommits --capture'
 
       <<-EOS
 ### lolcommits hook (begin) ###
-if [ ! -d "$GIT_DIR/rebase-merge" ]; then
-#{locale_export}#{hook_export}#{capture_cmd} #{capture_args}
+if [ ! -d "$GIT_DIR/rebase-merge" ] && [ "$LOLCOMMITS_CAPTURE_DISABLED" != "true" ]; then
+#{capture_cmd} #{capture_args}
 fi
 ###  lolcommits hook (end)  ###
 EOS

--- a/lib/lolcommits/backends/installation_git.rb
+++ b/lib/lolcommits/backends/installation_git.rb
@@ -58,7 +58,7 @@ module Lolcommits
     end
 
     def self.hook_script(capture_args = '')
-      # TODO have this return a single line bash like mercurial install, and DRY
+      # TODO: have this return a single line bash like mercurial install, and DRY
       # this method (only different in git is the rebase-merge check which could
       # be extracted
       ruby_path     = Lolcommits::Platform.command_which('ruby', true)

--- a/lib/lolcommits/backends/installation_mercurial.rb
+++ b/lib/lolcommits/backends/installation_mercurial.rb
@@ -43,14 +43,16 @@ module Lolcommits
       capture_cmd   = 'lolcommits --capture'
 
       if Lolcommits::Platform.platform_windows?
-        capture_cmd = "set path=#{ruby_path};#{imagick_path};%PATH%&&#{capture_cmd}"
+        capture_cmd = 'if "%LOLCOMMITS_CAPTURE_DISABLED%"=="true" (exit)'
+        capture_cmd = "set path=#{ruby_path};#{imagick_path};%PATH%&&#{capture_cmd} #{capture_args}"
       else
         locale_export = "LANG=\"#{ENV['LANG']}\""
         hook_export   = "PATH=\"#{ruby_path}:#{imagick_path}:$PATH\""
-        capture_cmd = "#{locale_export} #{hook_export} #{capture_cmd}"
+        capture_cmd   = "#{locale_export} #{hook_export} #{capture_cmd}"
+        capture_cmd   = "if [ \"$LOLCOMMITS_CAPTURE_DISABLED\" != \"true\" ]; then #{capture_cmd} #{capture_args}; fi"
       end
 
-      "#{capture_cmd} #{capture_args}"
+      capture_cmd
     end
 
     def self.repository
@@ -60,7 +62,7 @@ module Lolcommits
     # does a mercurial hook exist with lolcommits commands?
     def self.lolcommits_hook_exists?
       config = repository.config
-      config.exists? && config.setting_exists?(HOOK_SECTION, 'post-commit.lolcommits')
+      config.exists? && config.setting_exists?(HOOK_SECTION, 'post-crecord.lolcommits')
     end
 
     # can we load the hgrc?


### PR DESCRIPTION
Replaces #333 - exiting the post commit hook if ENV var `LOLCOMMITS_CAPTURE_DISABLED` is true.  Should work for all platforms and on both Git/Mercurial.