### PR TITLE
adjust poor word choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# lolcommits (git + webcam = lol)
+# lolcommits
+> git-based selfies for software developers
 
 lolcommits takes a snapshot with your webcam every time you git commit code, and
 archives a lolcat style image with it. Git blame has never been so much fun.
@@ -45,7 +46,7 @@ Then install with:
 	[sudo] gem install lolcommits
 
 If you're using RVM (or rbenv), you can/should probably omit the sudo, but the
-default macOS Ruby install is dumb and requires it.
+default macOS Ruby install usually requires it.
 
 Lolcommits v0.8.1 was the last release to support Ruby < 2.0. If you'd like to
 use older Rubies try:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -25,7 +25,7 @@ Before do
   set_env 'GIT_COMMITTER_EMAIL', author_email
 end
 
-# for tasks that may take an insanely long time (e.g. network related)
+# for tasks that may take an incredibly long time (e.g. network related)
 # we should strive to not have any of these in our scenarios, naturally.
 Before('@slow_process') do
   @aruba_io_wait_seconds = 5

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -89,7 +89,7 @@ module Lolcommits
       debug 'Runner: resizing snapshot'
       image = MiniMagick::Image.open(snapshot_loc)
       if image[:width] > 640 || image[:height] > 480
-        # this is ghetto resize-to-fill
+        # this is hacky resize-to-fill
         image.combine_options do |c|
           c.resize '640x480^'
           c.gravity 'center'


### PR DESCRIPTION
apparently when writing code comments, I previously used terms that I would try to avoid using in real life.

I was originally going to just commit this to master since its a tiny change affecting comments only, but decided to PR it to raise visibility and hold myself accountable.

In the future, I am interested in developing a handy code-linter to look for stuff like this (perhaps using dariusk/wordfilter as a starting template?)

also updates the README to use the same slogan we use elsewhere.