### PR TITLE
Add captureready plugin hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,25 +191,25 @@ page](https://github.com/mroth/lolcommits/wiki/Configuring-Plugins).
 
 Until recently, all plugins lived inside the main lolcommits gem. We are in the
 process of extracting them to individual gems. For [gem
-plugins](https://github.com/lolcommits), you'll need
-to install the gem first:
+plugins](https://github.com/search?q=topic%3Alolcommits-plugin+org%3Alolcommits&type=Repositories),
+you'll need to install the gem first:
 
     [sudo] gem install lolcommits-plugin-sample
 
-To list available/installed plugins use:
+To list all installed plugins use:
 
     lolcommits --plugins
 
-Plugins can be easily enabled, configured or disabled with the `--config`
-option:
+Installed plugins can be easily enabled, configured or disabled with the
+`--config` option:
 
     lolcommits --config
     # or
     lolcommits --config -p loltext
 
 Interested in developing your own plugin? Follow this [this simple
-guide](https://github.com/lolcommits/lolcommits-plugin-sample) for the
-Lolcommits Plugin Sample gem.
+guide](https://github.com/lolcommits/lolcommits-plugin-sample) at the
+Lolcommits Plugin Sample README.
 
 
 ## Timelapse

--- a/lib/lolcommits/plugin/base.rb
+++ b/lib/lolcommits/plugin/base.rb
@@ -9,22 +9,28 @@ module Lolcommits
       end
 
       def execute_precapture
-        return unless valid_configuration?
-        return unless enabled?
+        return unless configured_and_enabled?
         debug 'I am enabled, about to run precapture'
         run_precapture
       end
 
       def execute_postcapture
-        return unless valid_configuration?
-        return unless enabled?
+        return unless configured_and_enabled?
         debug 'I am enabled, about to run postcapture'
         run_postcapture
+      end
+
+      def execute_captureready
+        return unless configured_and_enabled?
+        debug 'I am enabled, about to run captureready'
+        run_captureready
       end
 
       def run_precapture; end
 
       def run_postcapture; end
+
+      def run_captureready; end
 
       def configuration
         config = runner.config.read_configuration if runner
@@ -61,6 +67,10 @@ module Lolcommits
         else
           str
         end
+      end
+
+      def configured_and_enabled?
+        valid_configuration? && enabled?
       end
 
       def enabled?
@@ -105,8 +115,11 @@ module Lolcommits
       #
       # Defines when the plugin will execute in the capture process. This must
       # be defined, if the method returns nil, or [] the plugin will never run.
+      # Three hook positions exist, your plugin code can execute in one or more
+      # of these.
       #
-      # @return [Array] the position(s) (:precapture and/or :postcapture)
+      # @return [Array] the position(s) (:precapture, :postcapture,
+      # :captureready)
       #
       def self.runner_order
         []

--- a/lib/lolcommits/plugin/dot_com.rb
+++ b/lib/lolcommits/plugin/dot_com.rb
@@ -10,7 +10,7 @@ module Lolcommits
         options.concat(%w(api_key api_secret repo_id))
       end
 
-      def run_postcapture
+      def run_captureready
         t = Time.now.to_i.to_s
         HTTMultiParty.post(
           "#{BASE_URL}/git_commits.json",
@@ -43,7 +43,7 @@ module Lolcommits
       end
 
       def self.runner_order
-        :postcapture
+        :captureready
       end
     end
   end

--- a/lib/lolcommits/plugin/lol_flowdock.rb
+++ b/lib/lolcommits/plugin/lol_flowdock.rb
@@ -11,7 +11,7 @@ module Lolcommits
       end
 
       def self.runner_order
-        :postcapture
+        :captureready
       end
 
       def configured?
@@ -45,7 +45,7 @@ module Lolcommits
         options
       end
 
-      def run_postcapture
+      def run_captureready
         retries = RETRY_COUNT
         begin
 

--- a/lib/lolcommits/plugin/lol_hipchat.rb
+++ b/lib/lolcommits/plugin/lol_hipchat.rb
@@ -32,7 +32,7 @@ module Lolcommits
         }
       end
 
-      def run_postcapture
+      def run_captureready
         http = Net::HTTP.new(api_url.host, api_url.port)
         # http.set_debug_output $stderr # nice for debugging, never ever release with it
         http.start do |connection|
@@ -117,7 +117,7 @@ module Lolcommits
       end
 
       def self.runner_order
-        :postcapture
+        :captureready
       end
     end
   end

--- a/lib/lolcommits/plugin/lol_protonet.rb
+++ b/lib/lolcommits/plugin/lol_protonet.rb
@@ -8,7 +8,7 @@ module Lolcommits
         options.concat(%w(api_token api_endpoint))
       end
 
-      def run_postcapture
+      def run_captureready
         debug "Posting capture to #{configuration['endpoint']}"
         RestClient.post(
           api_url,
@@ -61,7 +61,7 @@ module Lolcommits
       end
 
       def self.runner_order
-        :postcapture
+        :captureready
       end
     end
   end

--- a/lib/lolcommits/plugin/lol_slack.rb
+++ b/lib/lolcommits/plugin/lol_slack.rb
@@ -11,7 +11,7 @@ module Lolcommits
       end
 
       def self.runner_order
-        :postcapture
+        :captureready
       end
 
       def configured?
@@ -40,7 +40,7 @@ module Lolcommits
         options
       end
 
-      def run_postcapture
+      def run_captureready
         retries = RETRY_COUNT
         begin
 

--- a/lib/lolcommits/plugin/lol_tumblr.rb
+++ b/lib/lolcommits/plugin/lol_tumblr.rb
@@ -11,7 +11,7 @@ module Lolcommits
       TUMBLR_CONSUMER_KEY    = '2FtMEDpEPkxjoUdkpHh42h9wqTu9IVS7Ra0QyNZGixdCvhllN2'.freeze
       TUMBLR_CONSUMER_SECRET = 'qWuvxgFUR2YyWKtbWOkDTMAiBEbj7ZGaNLaNQPba0PI1N4JpBs'.freeze
 
-      def run_postcapture
+      def run_captureready
         puts 'Posting to Tumblr'
         r = client.photo(configuration['tumblr_name'], data: runner.main_image)
         if r.key?('id')
@@ -111,7 +111,7 @@ module Lolcommits
       end
 
       def self.runner_order
-        :postcapture
+        :captureready
       end
 
       protected

--- a/lib/lolcommits/plugin/lol_twitter.rb
+++ b/lib/lolcommits/plugin/lol_twitter.rb
@@ -15,7 +15,7 @@ module Lolcommits
       TWITTER_PIN_REGEX            = /^\d{4,}$/ # 4 or more digits
       DEFAULT_SUFFIX               = '#lolcommits'.freeze
 
-      def run_postcapture
+      def run_captureready
         tweet = build_tweet(runner.message)
 
         attempts = 0
@@ -169,7 +169,7 @@ module Lolcommits
       end
 
       def self.runner_order
-        :postcapture
+        :captureready
       end
     end
   end

--- a/lib/lolcommits/plugin/lol_yammer.rb
+++ b/lib/lolcommits/plugin/lol_yammer.rb
@@ -15,7 +15,7 @@ module Lolcommits
       end
 
       def self.runner_order
-        :postcapture
+        :captureready
       end
 
       def configured?
@@ -53,7 +53,7 @@ module Lolcommits
         options
       end
 
-      def run_postcapture
+      def run_captureready
         commit_msg = runner.message
         post = "#{commit_msg} #lolcommits"
         puts "Yammer post: #{post}" unless runner.capture_stealth

--- a/lib/lolcommits/plugin/lolsrv.rb
+++ b/lib/lolcommits/plugin/lolsrv.rb
@@ -10,7 +10,7 @@ module Lolcommits
         options << 'server'
       end
 
-      def run_postcapture
+      def run_captureready
         fork { sync }
       end
 
@@ -51,7 +51,7 @@ module Lolcommits
       end
 
       def self.runner_order
-        :postcapture
+        :captureready
       end
     end
   end

--- a/lib/lolcommits/plugin/term_output.rb
+++ b/lib/lolcommits/plugin/term_output.rb
@@ -3,7 +3,7 @@ require 'base64'
 module Lolcommits
   module Plugin
     class TermOutput < Base
-      def run_postcapture
+      def run_captureready
         if terminal_supported?
           if !runner.vcs_info || runner.vcs_info.repo.empty?
             debug 'repo is empty, skipping term output'
@@ -21,7 +21,7 @@ module Lolcommits
       end
 
       def self.runner_order
-        :postcapture
+        :captureready
       end
 
       def configure_options!

--- a/lib/lolcommits/plugin/uploldz.rb
+++ b/lib/lolcommits/plugin/uploldz.rb
@@ -18,7 +18,7 @@ module Lolcommits
         )
       end
 
-      def run_postcapture
+      def run_captureready
         if !runner.vcs_info || runner.vcs_info.repo.empty?
           puts 'Repo is empty, skipping upload'
         else
@@ -58,7 +58,7 @@ module Lolcommits
       end
 
       def self.runner_order
-        :postcapture
+        :captureready
       end
     end
   end

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -41,12 +41,17 @@ module Lolcommits
         ## resize snapshot first
         resize_snapshot!
 
-        # execute postcapture plugins
+        # execute postcapture plugins, use to alter the capture
         plugin_manager.plugins_for(:postcapture).each do |plugin|
           plugin.new(self).execute_postcapture
         end
 
-        # do things that should happen last
+        # execute captureready plugins, capture is ready for export/sharing
+        plugin_manager.plugins_for(:captureready).each do |plugin|
+          plugin.new(self).execute_captureready
+        end
+
+        # clean away any tmp files
         cleanup!
       else
         debug 'Runner: failed to capture a snapshot'


### PR DESCRIPTION
After [this discussion](https://github.com/mroth/lolcommits/pull/339#issuecomment-294362013) on #99 - this introduces a new plugin hook point `:captureready`.

So we can distinguish between plugins that alter the capture in anyway, and plugins that share or export the finalised image.

After merging/releasing, I'll adjust the plugin dev guide [here](https://github.com/lolcommits/lolcommits-plugin-sample).

Some minor README and comment updates too.