### PR TITLE
Clean legacy methods and small hipchat plugin fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,11 @@
 AllCops:
   Exclude:
-    - vendor/bundle/**/*
-    - .bundle/**/*
-    - '**/.irbrc'
+    - 'vendor/bundle/**/*'
+    - 'vendor/bundle/**/.*'
+    - '.bundle/**/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'lolcommits.gemspec'
 
 inherit_from: .rubocop_todo.yml

--- a/lib/lolcommits/plugin/base.rb
+++ b/lib/lolcommits/plugin/base.rb
@@ -12,21 +12,18 @@ module Lolcommits
       def execute_pre_capture
         return unless configured_and_enabled?
         debug 'I am enabled, about to run pre capture'
-        run_precapture # TODO: remove me (legacy method)
         run_pre_capture
       end
 
       def execute_post_capture
         return unless configured_and_enabled?
         debug 'I am enabled, about to run post capture'
-        run_postcapture # TODO: remove me (legacy method)
         run_post_capture
       end
 
       def execute_capture_ready
         return unless configured_and_enabled?
         debug 'I am enabled, about to run capture ready'
-        run_captureready # TODO: remove me (legacy method)
         run_capture_ready
       end
 
@@ -133,13 +130,6 @@ module Lolcommits
       def self.runner_order
         []
       end
-
-      # TODO: remove these legacy methods
-      def run_precapture; end
-
-      def run_postcapture; end
-
-      def run_captureready; end
     end
   end
 end

--- a/lib/lolcommits/plugin/lol_hipchat.rb
+++ b/lib/lolcommits/plugin/lol_hipchat.rb
@@ -74,7 +74,7 @@ module Lolcommits
       end
 
       def api_url
-        URI(format('http://%<api_team>.hipchat.com/v2/room/%<api_room>/share/file?auth_token=%<api_token>', symbolized_configuration))
+        URI(format('http://%<api_team>s.hipchat.com/v2/room/%<api_room>s/share/file?auth_token=%<api_token>s', symbolized_configuration))
       end
 
       def symbolized_configuration

--- a/lib/lolcommits/plugin_manager.rb
+++ b/lib/lolcommits/plugin_manager.rb
@@ -19,11 +19,7 @@ module Lolcommits
     end
 
     def plugins_for(position)
-      plugin_klasses.select do |p|
-        # TODO: remove (legacy support) position munging after 0.9.5 release
-        Array(p.runner_order).include?(position) ||
-          Array(p.runner_order).include?(position.to_s.delete('_').to_sym)
-      end
+      plugin_klasses.select { |p| Array(p.runner_order).include?(position) }
     end
 
     # @return [Lolcommits::Plugin] find first plugin matching name

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -49,8 +49,8 @@ EOF
   s.requirements << 'a webcam'
 
   # hold back upgrading (and why)
-  s.add_development_dependency('aruba', '=0.6.2')  # upgrading requires a lot of test code changes
-  s.add_development_dependency('rake', '=10.5.0')  # ~> 11+ introduces lots of warnings from other deps
+  s.add_development_dependency('aruba', '=0.6.2') # upgrading requires a lot of test code changes
+  s.add_development_dependency('rake', '=10.5.0') # ~> 11+ introduces lots of warnings from other deps
   s.add_runtime_dependency('net-http-persistent', '=2.9.4') # ~> 3+ requires Ruby 2.1
 
   # core
@@ -62,7 +62,7 @@ EOF
   s.add_runtime_dependency('git', '~> 1.3.0')
 
   # built-in lolcommits plugin
-  s.add_runtime_dependency('lolcommits-loltext') # TODO: add min 0.0.4
+  s.add_runtime_dependency('lolcommits-loltext', '~> 0.0.4')
 
   # plugin gems
   s.add_runtime_dependency('yam', '~> 2.5.0')            # yammer


### PR DESCRIPTION
Small PR to clean out legacy plugin methods, now that all plugins (and plugin gems) have been refectored to have these. 

* built-in lolcommits-loltext gem v0.0.4 min now required
* hip chat plugin fixed
* rubocop updates/fixes