### PR TITLE
Pin public_suffix gem version (ruby 2.0)

### DIFF
--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -52,6 +52,7 @@ EOF
   s.add_development_dependency('aruba', '=0.6.2') # upgrading requires a lot of test code changes
   s.add_development_dependency('rake', '=10.5.0') # ~> 11+ introduces lots of warnings from other deps
   s.add_runtime_dependency('net-http-persistent', '=2.9.4') # ~> 3+ requires Ruby 2.1
+  s.add_runtime_dependency('public_suffix', '~>2.0.0') # ~> 3+ requires Ruby 2.1
 
   # core
   s.add_runtime_dependency('methadone', '~> 1.9.5')


### PR DESCRIPTION
To maintain compatibility with Ruby 2.0 (which we currently still support) - pin the [public_suffix](https://rubygems.org/gems/public_suffix) gem to `~>2.0.0`.  Addressable gem has a dep on public_suffix which became incompatible with Ruby 2.0 on Aug 4th 2017.