### PR TITLE
Plugin config improvements

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,7 +48,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 23
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 23
+  Max: 24
 
 # Offense count: 5
 Metrics/PerceivedComplexity:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ cache: bundler
 rvm:
  - 2.0.0
  - 2.1.10
- - 2.2.8
- - 2.3.5
- - 2.4.2
+ - 2.2.9
+ - 2.3.6
+ - 2.4.3
  - ruby-head
 
 before_install:

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -123,7 +123,7 @@ Feature: Basic UI functionality
       Then the output should contain "Disabling plugin: loltext - answer with 'true' to enable & configure"
     And a file named "~/.lolcommits/test/config.yml" should exist
     When I successfully run `lolcommits --test --show-config`
-    Then the output should match /loltext:\s+enabled: false/
+    Then the output should match /loltext:\s+:enabled: false/
 
   Scenario: test capture should work regardless of whether in a lolrepo
     Given I am in a directory named "nothingtoseehere"

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -161,7 +161,7 @@ end
 
 Then(/^the output should contain a list of plugins$/) do
   step %(the output should contain "Installed plugins: (* enabled)")
-  step %(the output should contain "[-] loltext")
+  step %(the output should contain "[*] loltext")
 end
 
 When(/^I do a git commit with commit message "(.*?)"$/) do |commit_msg|

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -160,7 +160,7 @@ Then(/^there should be exactly (.*?) (jpg|gif|pid)s? in "(.*?)"$/) do |n, type, 
 end
 
 Then(/^the output should contain a list of plugins$/) do
-  step %(the output should contain "Installed plugins: (+ enabled)")
+  step %(the output should contain "Installed plugins: (* enabled)")
   step %(the output should contain "[-] loltext")
 end
 

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -160,7 +160,8 @@ Then(/^there should be exactly (.*?) (jpg|gif|pid)s? in "(.*?)"$/) do |n, type, 
 end
 
 Then(/^the output should contain a list of plugins$/) do
-  step %(the output should contain "Available plugins: ")
+  step %(the output should contain "Installed plugins: (+ enabled)")
+  step %(the output should contain "[-] loltext")
 end
 
 When(/^I do a git commit with commit message "(.*?)"$/) do |commit_msg|

--- a/lib/core_ext/hash/hash_dig.rb
+++ b/lib/core_ext/hash/hash_dig.rb
@@ -1,0 +1,21 @@
+# Backport Hash#dig to Ruby < 2.3
+# inspired by https://github.com/Invoca/ruby_dig
+
+module HashDig
+  def dig(key, *rest)
+    value = self[key]
+    if value.nil? || rest.empty?
+      value
+    elsif value.respond_to?(:dig)
+      value.dig(*rest)
+    else
+      raise TypeError, "#{value.class} does not have #dig method"
+    end
+  end
+end
+
+if RUBY_VERSION < '2.3'
+  class Hash
+    include HashDig
+  end
+end

--- a/lib/lolcommits.rb
+++ b/lib/lolcommits.rb
@@ -1,5 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('.')
 
+require 'core_ext/hash/hash_dig' # backport Hash#dig for Ruby < 2.3
+
 require 'mini_magick'
 require 'core_ext/mini_magick/utilities'
 require 'fileutils'

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -69,8 +69,9 @@ module Lolcommits
     def list_plugins
       puts "Installed plugins: (* enabled)\n"
 
-      plugin_manager.plugin_names.each do |name|
-        puts " [#{yaml[name] && yaml[name]['enabled'] ? '*' : '-'}] #{name}"
+      plugin_manager.plugins.each do |gem_plugin|
+        plugin = gem_plugin.plugin_klass.new(config: yaml[gem_plugin.name])
+        puts " [#{plugin.enabled? ? '*' : '-'}] #{gem_plugin.name}"
       end
     end
 

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -114,6 +114,8 @@ module Lolcommits
       end
     ensure
       if plugin
+        # clean away legacy enabled key, later we can remove this
+        plugin_config.delete('enabled')
         # save plugin config (if we have anything in the hash)
         save(plugin.name, plugin_config) unless plugin_config.empty?
 

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -114,8 +114,8 @@ module Lolcommits
       end
     ensure
       if plugin
-        # save plugin config
-        save(plugin.name, plugin_config)
+        # save plugin config (if we have anything in the hash)
+        save(plugin.name, plugin_config) unless plugin_config.empty?
 
         # print config if plugin was enabled
         if plugin_config[:enabled]

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -100,7 +100,7 @@ module Lolcommits
       puts "Configuring plugin: #{plugin.name}\n"
       plugin_config = plugin.plugin_klass.new(config: yaml[plugin_name]).configure_options! || {}
 
-      unless plugin_config['enabled']
+      unless plugin_config[:enabled]
         puts "Disabling plugin: #{plugin.name} - answer with 'true' to enable & configure"
       end
     rescue Interrupt
@@ -108,7 +108,7 @@ module Lolcommits
       if plugin
         puts "\nConfiguration aborted: #{plugin.name} has been disabled"
         plugin_config ||= {}
-        plugin_config['enabled'] = false
+        plugin_config[:enabled] = false
       else
         puts "\n"
       end
@@ -118,7 +118,7 @@ module Lolcommits
         save(plugin.name, plugin_config)
 
         # print config if plugin was enabled
-        if plugin_config['enabled']
+        if plugin_config[:enabled]
           puts "\nSuccessfully configured plugin: #{plugin.name} - at path '#{configuration_file}'"
           puts plugin_config.to_yaml.to_s
         end

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -105,12 +105,11 @@ module Lolcommits
       end
     rescue Interrupt
       # e.g. user Ctrl+c or aborted by plugin configure_options!
+      puts "\n"
       if plugin
-        puts "\nConfiguration aborted: #{plugin.name} has been disabled"
+        puts "Configuration aborted: #{plugin.name} has been disabled"
         plugin_config ||= {}
         plugin_config[:enabled] = false
-      else
-        puts "\n"
       end
     ensure
       if plugin

--- a/lib/lolcommits/gem_plugin.rb
+++ b/lib/lolcommits/gem_plugin.rb
@@ -44,6 +44,10 @@ module Lolcommits
       warn "failed to load constant from plugin gem '#{plugin_klass_name}: #{e}'"
     end
 
+    def plugin_instance(runner)
+      plugin_klass.new(runner: runner, config: runner.config.yaml[name])
+    end
+
     def gem_name
       gem_spec.name
     end
@@ -55,7 +59,12 @@ module Lolcommits
     end
 
     def plugin_klass_name
-      gem_path.split('/').map(&:capitalize).join('::')
+      # convert gem paths to plugin classes e.g.
+      # lolcommits/loltext --> Lolcommits::Plugin::Loltext
+      # lolcommits/term_output --> Lolcommits::Plugin::TermOutput
+      gem_path.split('/').insert(1, 'plugin').collect do |c|
+        c.split('_').collect(&:capitalize).join
+      end.join('::')
     end
   end
 end

--- a/lib/lolcommits/plugin/base.rb
+++ b/lib/lolcommits/plugin/base.rb
@@ -13,24 +13,6 @@ module Lolcommits
         self.options = ['enabled']
       end
 
-      def execute_pre_capture
-        return unless configured_and_enabled?
-        debug 'I am enabled, about to run pre capture'
-        run_pre_capture
-      end
-
-      def execute_post_capture
-        return unless configured_and_enabled?
-        debug 'I am enabled, about to run post capture'
-        run_post_capture
-      end
-
-      def execute_capture_ready
-        return unless configured_and_enabled?
-        debug 'I am enabled, about to run capture ready'
-        run_capture_ready
-      end
-
       def run_pre_capture; end
 
       def run_post_capture; end
@@ -69,10 +51,6 @@ module Lolcommits
       def default_options
         # maps an array of option names to hash keys (with nil values)
         Hash[options.map { |key, _value| [key, nil] }]
-      end
-
-      def configured_and_enabled?
-        valid_configuration? && enabled?
       end
 
       def enabled?

--- a/lib/lolcommits/plugin/base.rb
+++ b/lib/lolcommits/plugin/base.rb
@@ -68,10 +68,11 @@ module Lolcommits
 
       # check config is valid
       def valid_configuration?
-        configured?
+        !configuration.empty?
       end
 
       # empty plugin configuration
+      # TODO: remove this method in after 0.9.9 release
       def configured?
         !configuration.empty?
       end

--- a/lib/lolcommits/plugin/base.rb
+++ b/lib/lolcommits/plugin/base.rb
@@ -1,6 +1,10 @@
+require 'lolcommits/plugin/configuration_helper'
+
 module Lolcommits
   module Plugin
     class Base
+      include Lolcommits::Plugin::ConfigurationHelper
+
       attr_accessor :runner, :configuration, :options
 
       def initialize(runner: nil, config: {})
@@ -41,21 +45,6 @@ module Lolcommits
           # if not enabled, abort and disable
           break { option => false } if option == 'enabled' && val != true
           acc.merge(option => val)
-        end
-      end
-
-      def parse_user_input(str)
-        # handle for bools, strings, ints and blanks
-        if 'true'.casecmp(str).zero?
-          true
-        elsif 'false'.casecmp(str).zero?
-          false
-        elsif str =~ /^[0-9]+$/
-          str.to_i
-        elsif str.strip.empty?
-          nil
-        else
-          str
         end
       end
 

--- a/lib/lolcommits/plugin/configuration_helper.rb
+++ b/lib/lolcommits/plugin/configuration_helper.rb
@@ -1,0 +1,51 @@
+module Lolcommits
+  module Plugin
+    module ConfigurationHelper
+      # handle for bools, strings, ints and blanks from user input
+      def parse_user_input(str)
+        if 'true'.casecmp(str).zero?
+          true
+        elsif 'false'.casecmp(str).zero?
+          false
+        elsif str =~ /^[0-9]+$/
+          str.to_i
+        elsif str.strip.empty?
+          nil
+        else
+          str
+        end
+      end
+
+      # user input with autocomplete (via tab) through array of named values
+      #
+      # e.g.
+      # prompt_autocomplete_hash("Organization: ", orgs)
+      #
+      # where orgs are an array of hashes like so (with string keys):
+      # [
+      #   { 'name' => 'some human readable name', 'value' => 1234 },
+      # ]
+      # User will be asked for Organization, can tab to autocomplete, and chose
+      # value is returned.
+      def prompt_autocomplete_hash(prompt, items, name: 'name', value: 'value', suggest_words: 5)
+        words = items.map { |item| item[name] }.sort
+        puts "e.g. #{words.take(suggest_words).join(', ')}" if suggest_words > 0
+        completed_input = gets_autocomplete(prompt, words)
+        items.find { |item| item[name] == completed_input }[value]
+      end
+
+      private
+
+      def gets_autocomplete(prompt, words)
+        completion_handler = proc { |s| words.grep(/^#{Regexp.escape(s)}/) }
+        Readline.completion_append_character = ''
+        Readline.completion_proc = completion_handler
+
+        while (line = Readline.readline(prompt, true).strip)
+          return line if words.include?(line)
+          puts "'#{line}' not found"
+        end
+      end
+    end
+  end
+end

--- a/lib/lolcommits/plugin/configuration_helper.rb
+++ b/lib/lolcommits/plugin/configuration_helper.rb
@@ -25,7 +25,7 @@ module Lolcommits
       # [
       #   { 'name' => 'some human readable name', 'value' => 1234 },
       # ]
-      # User will be asked for Organization, can tab to autocomplete, and chose
+      # User will be asked for Organization, can tab to autocomplete, and chosen
       # value is returned.
       def prompt_autocomplete_hash(prompt, items, name: 'name', value: 'value', suggest_words: 5)
         words = items.map { |item| item[name] }.sort

--- a/lib/lolcommits/plugin_manager.rb
+++ b/lib/lolcommits/plugin_manager.rb
@@ -8,6 +8,8 @@ module Lolcommits
       pm
     end
 
+    attr_reader :plugins
+
     def initialize
       @plugins = []
     end

--- a/lib/lolcommits/plugin_manager.rb
+++ b/lib/lolcommits/plugin_manager.rb
@@ -19,28 +19,21 @@ module Lolcommits
     end
 
     def plugins_for(position)
-      plugin_klasses.select { |p| Array(p.runner_order).include?(position) }
+      @plugins.select do |plugin|
+        Array(plugin.plugin_klass.runner_order).include?(position)
+      end
     end
 
-    # @return [Lolcommits::Plugin] find first plugin matching name
+    # @return [Lolcommits::Plugin] finds the first plugin matching name
     def find_by_name(name)
-      plugin_klasses.find { |plugin| plugin.name =~ /^#{name}/ }
+      @plugins.find { |plugin| plugin.name =~ /^#{name}/ } unless name.empty?
     end
 
     def plugin_names
-      # TODO: when all plugins are gems, get names from GemPlugin with
-      #   @plugins.map(&:name)
-      plugin_klasses.map(&:name).sort
+      @plugins.map(&:name).sort
     end
 
     private
-
-    # @return [Array] find all classes inheriting from Lolcommits::Plugin::Base
-    def plugin_klasses
-      # TODO: when all plugins are gems, change this to
-      #   @plugins.map(&:plugin_klass)
-      ObjectSpace.each_object(Class).select { |klass| klass < Lolcommits::Plugin::Base }
-    end
 
     # @return [Array] find all installed and supported plugins, populate
     #   @plugins array and return it

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -30,7 +30,7 @@ module Lolcommits
     def run
       # do plugins that need to happen before capture
       plugin_manager.plugins_for(:pre_capture).each do |plugin|
-        plugin.new(runner: self).execute_pre_capture
+        plugin.plugin_instance(self).execute_pre_capture
       end
 
       # do main capture to snapshot_loc
@@ -43,12 +43,12 @@ module Lolcommits
 
         # execute post_capture plugins, use to alter the capture
         plugin_manager.plugins_for(:post_capture).each do |plugin|
-          plugin.new(runner: self).execute_post_capture
+          plugin.plugin_instance(self).execute_post_capture
         end
 
         # execute capture_ready plugins, capture is ready for export/sharing
         plugin_manager.plugins_for(:capture_ready).each do |plugin|
-          plugin.new(runner: self).execute_capture_ready
+          plugin.plugin_instance(self).execute_capture_ready
         end
 
         # clean away any tmp files

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -64,7 +64,7 @@ POSTINSTALL
   s.add_runtime_dependency('git', '~> 1.3.0')
 
   # included plugins
-  s.add_runtime_dependency('lolcommits-loltext', '~> 0.0.4')
+  s.add_runtime_dependency('lolcommits-loltext', '~> 0.0.5')
 
   # development & test gems
   s.add_development_dependency('rdoc')


### PR DESCRIPTION
A few improvements when configuring plugins:

* when listing plugins, you can now see if they are currently enabled (or not)
* default option hash is now available for use in plugins, with nested config and default values (lolcommits-loltext will be refactored to use this)
* if `valid_configuration?` fails, plugin hook fails to execute (as before), and a new warning message is shown
* `Lolcommits::Plugin::ConfigurationHelper` now available with `parse_user_input` method and `prompt_autocomplete_hash` (a user can tab in cmd line to autocomplete suggested option values from a list)

⚠️ **NOTE**: This PR changes the enabled option from a string key, to a symbol. Most of the existing plugin gems will be updated to do the same and make use of the other changes.
  
This PR also bumps up the Travis Ruby versions in `.travis.yml`