### PR TITLE
Require at least Ruby 2.1 and update gem dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
- - 2.0.0
  - 2.1.10
  - 2.2.9
  - 2.3.6

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'pry-remote'

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,6 @@ CLEAN << CUKE_RESULTS
 Cucumber::Rake::Task.new(:features) do |t|
   optstr = "features --format html -o #{CUKE_RESULTS} --format progress -x"
   optstr << " --tags @#{ENV['tag']}" unless ENV['tag'].nil?
-  optstr << ' --tags ~@unstable' if ENV['tag'].nil? # ignore unstable tests unless specifying something at CLI
   t.cucumber_opts = optstr
   t.fork = false
 end

--- a/features/bugs.feature
+++ b/features/bugs.feature
@@ -11,20 +11,19 @@ Feature: Bug regression testing
   #
   Scenario: handle git repos with spaces in directory name
     Given I am in a git repo named "test lolol" with lolcommits enabled
-    And I successfully run `git commit --allow-empty -m 'can haz commit'`
+    And I run `git commit --allow-empty -m 'can haz commit'`
     Then the output should contain "*** Preserving this moment in history."
     And a directory named "../.lolcommits/test-lolol" should exist
 
   #
   # issue #68, https://github.com/mroth/lolcommits/issues/68
   #
-  @fake-interactive-rebase @slow_process @unstable
+  @fake-interactive-rebase @slow_process
   Scenario: Don't trigger capture during a git rebase
     Given I am in a git repo named "yuh8history" with lolcommits enabled
-      And I do 6 git commits
-    When I successfully run `git rebase -i HEAD~5`
-    # Then there should be 4 commit entries in the git log
-    Then there should be exactly 6 jpgs in "../.lolcommits/yuh8history"
+      And I do 3 git commits
+    When I run `git rebase -i HEAD~2`
+    Then there should be exactly 3 jpgs in "~/.lolcommits/yuh8history"
 
   #
   # issue #87, https://github.com/mroth/lolcommits/issues/87
@@ -43,7 +42,7 @@ Feature: Bug regression testing
   #
   Scenario: catch upstream bug with ruby-git and color=always
     Given I am in a git repo named "whatev" with lolcommits enabled
-    And I successfully run `git config color.ui always`
+    And I run `git config color.ui always`
     When I run `lolcommits`
     Then the output should contain:
       """

--- a/features/lolcommits.feature
+++ b/features/lolcommits.feature
@@ -22,7 +22,7 @@ Feature: Basic UI functionality
 
   Scenario: Enable in a naked git repo
     Given I am in a git repo
-    When I successfully run `lolcommits --enable`
+    When I run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
       And the lolcommits git post-commit hook should be properly installed
       And the exit status should be 0
@@ -30,7 +30,7 @@ Feature: Basic UI functionality
   Scenario: Enable in a git repo that already has a git post-commit hook
     Given I am in a git repo
     And a git post-commit hook with "#!/bin/sh\n\n/my/own/script"
-    When I successfully run `lolcommits --enable`
+    When I run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
       And the lolcommits git post-commit hook should be properly installed
       And the git post-commit hook should contain "#!/bin/sh"
@@ -47,13 +47,13 @@ Feature: Basic UI functionality
 
   Scenario: Enable in a git repo passing capture arguments
     Given I am in a git repo
-    When I successfully run `lolcommits --enable -w 5 --fork --stealth --device 'My Devce'`
+    When I run `lolcommits --enable -w 5 --fork --stealth --device 'My Devce'`
     Then the git post-commit hook should contain "lolcommits --capture --delay 5 --fork --stealth --device 'My Devce'"
     And the exit status should be 0
 
   Scenario: Disable in a enabled git repo
     Given I am in a git repo with lolcommits enabled
-    When I successfully run `lolcommits --disable`
+    When I run `lolcommits --disable`
     Then the output should contain "uninstalled"
     And a file named ".git/hooks/post-commit" should exist
     And the exit status should be 0
@@ -112,17 +112,16 @@ Feature: Basic UI functionality
     And there should be exactly 1 jpg in its loldir
 
   Scenario: Show plugins
-    When I successfully run `lolcommits --plugins`
+    When I run `lolcommits --plugins`
     Then the output should contain a list of plugins
 
   Scenario: Configuring loltext plugin in test mode affects test loldir not repo loldir
     Given I am in a git repo named "testmode-config-test"
     When I run `lolcommits --config --test -p loltext` interactively
-      And I wait for output to contain "enabled:"
       Then I type "false"
       Then the output should contain "Disabling plugin: loltext - answer with 'true' to enable & configure"
     And a file named "~/.lolcommits/test/config.yml" should exist
-    When I successfully run `lolcommits --test --show-config`
+    When I run `lolcommits --test --show-config`
     Then the output should match /loltext:\s+:enabled: false/
 
   Scenario: test capture should work regardless of whether in a lolrepo
@@ -134,7 +133,7 @@ Feature: Basic UI functionality
 
   Scenario: test capture should store in its own test directory
     Given I am in a git repo named "randomgitrepo" with lolcommits enabled
-    When I successfully run `lolcommits --test --capture`
+    When I run `lolcommits --test --capture`
     Then a directory named "~/.lolcommits/test" should exist
     And a directory named "~/.lolcommits/randomgitrepo" should not exist
 
@@ -156,9 +155,8 @@ Feature: Basic UI functionality
       """
     And the exit status should be 0
 
-  @in-tempdir
-  Scenario: last command should fail gracefully if not in a lolrepo
-    Given I am in a directory named "gitsuxcvs4eva"
+  @no-repo-dir
+  Scenario: last command should fail gracefully if not in a repo
     When I run `lolcommits --last`
     Then the output should contain:
       """
@@ -166,10 +164,18 @@ Feature: Basic UI functionality
       """
     And the exit status should be 1
 
-  @in-tempdir
-  Scenario: Configuring loltext plugin if not in a lolrepo
-    Given I am in a directory named "gitsuxcvs4eva"
+  @no-repo-dir
+  Scenario: Configuring loltext plugin if not in a repo
     When I run `lolcommits --config`
+    Then the output should contain:
+      """
+      You don't appear to be in a directory of a supported vcs project.
+      """
+    And the exit status should be 1
+
+  @no-repo-dir
+  Scenario: browse command should fail gracefully when not in a repo
+    When I run `lolcommits --browse`
     Then the output should contain:
       """
       You don't appear to be in a directory of a supported vcs project.
@@ -204,26 +210,16 @@ Feature: Basic UI functionality
       """
     And the exit status should be 0
 
-  @in-tempdir
-  Scenario: browse command should fail gracefully when not in a lolrepo
-    Given I am in a directory named "gitsuxcvs4eva"
-    When I run `lolcommits --browse`
-    Then the output should contain:
-      """
-      You don't appear to be in a directory of a supported vcs project.
-      """
-    And the exit status should be 1
-
   Scenario: handle git commit messages with quotation marks
     Given I am in a git repo with lolcommits enabled
-    When I successfully run `git commit --allow-empty -m 'no "air quotes" bae'`
+    When I run `git commit --allow-empty -m 'no "air quotes" bae'`
     Then the exit status should be 0
     And there should be exactly 1 jpg in its loldir
 
   Scenario: generate gif should store in its own archive directory
     Given I am in a git repo named "giffy" with lolcommits enabled
       And a loldir named "giffy" with 2 lolimages
-    When I successfully run `lolcommits --timelapse`
+    When I run `lolcommits --timelapse`
     Then the output should contain "Generating animated gif."
       And a directory named "~/.lolcommits/giffy/archive" should exist
       And a file named "~/.lolcommits/giffy/archive/archive.gif" should exist
@@ -231,7 +227,7 @@ Feature: Basic UI functionality
   Scenario: generate gif with argument 'today'
     Given I am in a git repo named "sunday" with lolcommits enabled
       And a loldir named "sunday" with 2 lolimages
-    When I successfully run `lolcommits --timelapse --period today`
+    When I run `lolcommits --timelapse --period today`
     Then there should be exactly 1 gif in "~/.lolcommits/sunday/archive"
 
   @mac-only
@@ -258,13 +254,13 @@ Feature: Basic UI functionality
   Scenario: Enable on windows platform setting PATH in git post-commit hook
     Given I am using a "win32" platform
       And I am in a git repo
-    When I successfully run `lolcommits --enable`
+    When I run `lolcommits --enable`
     Then the git post-commit hook should contain "set path"
     And the exit status should be 0
 
   Scenario: Enable in a naked mercurial repo
     Given I am in a mercurial repo
-    When I successfully run `lolcommits --enable`
+    When I run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
     And the lolcommits mercurial post-commit hook should be properly installed
     And the exit status should be 0
@@ -272,7 +268,7 @@ Feature: Basic UI functionality
   Scenario: Enable in a mercurial repo that already has a mercurial post-commit hook
     Given I am in a mercurial repo
     And a mercurial post-commit hook with "[hooks]\npost-commit.mine = /my/own/script"
-    When I successfully run `lolcommits --enable`
+    When I run `lolcommits --enable`
     Then the output should contain "installed lolcommit hook to:"
     And the lolcommits mercurial post-commit hook should be properly installed
     And the mercurial post-commit hook should contain "post-commit.mine = /my/own/script"
@@ -280,13 +276,13 @@ Feature: Basic UI functionality
 
   Scenario: Enable in a mercurial repo passing capture arguments
     Given I am in a mercurial repo
-    When I successfully run `lolcommits --enable -w 5 --fork`
+    When I run `lolcommits --enable -w 5 --fork`
     Then the mercurial post-commit hook should contain "lolcommits --capture --delay 5 --fork"
     And the exit status should be 0
 
   Scenario: Disable in a enabled mercurial repo
     Given I am in a mercurial repo with lolcommits enabled
-    When I successfully run `lolcommits --disable`
+    When I run `lolcommits --disable`
     Then the output should contain "uninstalled"
     And a file named ".hg/hgrc" should exist
     And the exit status should be 0
@@ -348,8 +344,8 @@ Feature: Basic UI functionality
 
   Scenario: handle mercurial commit messages with quotation marks
     Given I am in a mercurial repo with lolcommits enabled
-    When I successfully run `touch meh`
-    And I successfully run `hg add meh`
-    And I successfully run `hg commit -m 'no "air quotes" bae'`
+    When I run `touch meh`
+    And I run `hg add meh`
+    And I run `hg commit -m 'no "air quotes" bae'`
     Then the exit status should be 0
     And there should be exactly 1 jpg in its loldir

--- a/features/step_definitions/lolcommits_steps.rb
+++ b/features/step_definitions/lolcommits_steps.rb
@@ -14,7 +14,7 @@ def default_repo
 end
 
 def default_loldir
-  absolute_path("~/.lolcommits/#{default_repo}")
+  "~/.lolcommits/#{default_repo}"
 end
 
 Given(/^I am in a directory named "(.*?)"$/) do |dir_name|
@@ -26,7 +26,7 @@ end
 
 Given(/^a git repo named "(.*?)"$/) do |repo_name|
   steps %(
-   Given I successfully run `git init --quiet "#{repo_name}"`
+   Given I run `git init --quiet "#{repo_name}"`
     )
 end
 
@@ -46,7 +46,7 @@ end
 Given(/^I am in a git repo named "(.*?)" with lolcommits enabled$/) do |repo|
   steps %(
     Given I am in a git repo named "#{repo}"
-    And I successfully run `lolcommits --enable`
+    And I run `lolcommits --enable`
     )
 end
 
@@ -79,7 +79,7 @@ end
 
 Given(/^a mercurial repo named "(.*?)"$/) do |repo_name|
   steps %(
-   Given I successfully run `hg init "#{repo_name}"`
+   Given I run `hg init "#{repo_name}"`
     )
 end
 
@@ -99,7 +99,7 @@ end
 Given(/^I am in a mercurial repo named "(.*?)" with lolcommits enabled$/) do |repo|
   steps %(
     Given I am in a mercurial repo named "#{repo}"
-    And I successfully run `lolcommits --enable`
+    And I run `lolcommits --enable`
     )
 end
 
@@ -131,7 +131,7 @@ Then(/^the mercurial post\-commit hook (should|should not) contain "(.*?)"$/) do
 end
 
 Given(/^I have environment variable (.*?) set to (.*?)$/) do |var, value|
-  set_env var, value
+  set_environment_variable var, value
 end
 
 Given(/^its loldir has (\d+) lolimages$/) do |num_images|
@@ -141,7 +141,7 @@ Given(/^its loldir has (\d+) lolimages$/) do |num_images|
 end
 
 Given(/^a loldir named "(.*?)" with (\d+) lolimages$/) do |repo, num_images|
-  loldir = absolute_path("~/.lolcommits/#{repo}")
+  loldir = expand_path("~/.lolcommits/#{repo}")
   FileUtils.mkdir_p loldir
   num_images.to_i.times do
     hex = format('%011x', (rand * 0xfffffffffff)).to_s
@@ -156,7 +156,7 @@ Then(/^there should be exactly (.*?) (jpg|gif|pid)s? in its loldir$/) do |n, typ
 end
 
 Then(/^there should be exactly (.*?) (jpg|gif|pid)s? in "(.*?)"$/) do |n, type, folder|
-  expect(Dir[absolute_path(folder, "*.#{type}")].count).to eq(n.to_i)
+  expect(Dir[expand_path("#{folder}/*.#{type}")].count).to eq(n.to_i)
 end
 
 Then(/^the output should contain a list of plugins$/) do
@@ -168,8 +168,8 @@ When(/^I do a git commit with commit message "(.*?)"$/) do |commit_msg|
   filename = FFaker::Lorem.words(1).first
   steps %(
     Given a 98 byte file named "#{filename}"
-    And I successfully run `git add #{filename}`
-    And I successfully run `git commit -m "#{commit_msg}"`
+    And I run `git add #{filename}`
+    And I run `git commit -m "#{commit_msg}"`
     )
 end
 
@@ -180,7 +180,7 @@ end
 When(/^I do (\d+) git commits$/) do |n|
   n.to_i.times do
     step %(I do a git commit)
-    sleep 0.1
+    sleep 0.2
   end
 end
 
@@ -193,8 +193,8 @@ When(/^I do a mercurial commit with commit message "(.*?)"$/) do |commit_msg|
   filename = FFaker::Lorem.words(1).first
   steps %(
     Given a 98 byte file named "#{filename}"
-    And I successfully run `hg add #{filename}`
-    And I successfully run `hg commit -m "#{commit_msg}"`
+    And I run `hg add #{filename}`
+    And I run `hg commit -m "#{commit_msg}"`
     )
 end
 
@@ -215,10 +215,10 @@ Then(/^there should be (\d+) commit entries in the mercurial log$/) do |n|
 end
 
 Given(/^I am using a "(.*?)" platform$/) do |host_os_name|
-  set_env 'LOLCOMMITS_FAKE_HOST_OS', host_os_name
+  set_environment_variable 'LOLCOMMITS_FAKE_HOST_OS', host_os_name
 end
 
 When(/^I wait for the child process to exit in "(.*?)"$/) do |repo_name|
-  pid_loc = absolute_path("~/.lolcommits/#{repo_name}/lolcommits.pid")
+  pid_loc = expand_path("~/.lolcommits/#{repo_name}/lolcommits.pid")
   sleep 0.1 while File.exist?(pid_loc)
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -9,33 +9,36 @@ include Lolcommits
 
 World(PathHelpers)
 
-Before do
-  @aruba_timeout_seconds = 20
+Aruba.configure do |config|
+  config.exit_timeout = 20
+end
 
+Before do
   # prevent launchy from opening gifs in tests
-  set_env 'LAUNCHY_DRY_RUN', 'true'
-  set_env 'LOLCOMMITS_CAPTURER', 'Lolcommits::CaptureFake'
+  set_environment_variable 'LAUNCHY_DRY_RUN', 'true'
+  set_environment_variable 'LOLCOMMITS_CAPTURER', 'Lolcommits::CaptureFake'
 
   author_name  = 'Testy McTesterson'
   author_email = 'testy@tester.com'
 
-  set_env 'GIT_AUTHOR_NAME',     author_name
-  set_env 'GIT_COMMITTER_NAME',  author_name
-  set_env 'GIT_AUTHOR_EMAIL',    author_email
-  set_env 'GIT_COMMITTER_EMAIL', author_email
+  set_environment_variable 'GIT_AUTHOR_NAME',     author_name
+  set_environment_variable 'GIT_COMMITTER_NAME',  author_name
+  set_environment_variable 'GIT_AUTHOR_EMAIL',    author_email
+  set_environment_variable 'GIT_COMMITTER_EMAIL', author_email
 end
 
 # for tasks that may take an incredibly long time (e.g. network related)
 # we should strive to not have any of these in our scenarios, naturally.
 Before('@slow_process') do
-  @aruba_io_wait_seconds = 5
-  @aruba_timeout_seconds = 60
+  Aruba.configure do |config|
+    config.exit_timeout = 60
+  end
 end
 
 # in order to fake an interactive rebase, we replace the editor with a script
 # to simply squash a few random commits. in this case, using lines 3-5.
 Before('@fake-interactive-rebase') do
-  set_env 'GIT_EDITOR', "sed -i -e '3,5 s/pick/squash/g'"
+  set_environment_variable 'GIT_EDITOR', "sed -i -e '3,5 s/pick/squash/g'"
 end
 
 # adjust the path so tests dont see a global imagemagick install
@@ -48,11 +51,20 @@ Before('@fake-no-ffmpeg') do
   reject_paths_with_cmd('ffmpeg')
 end
 
-# do test in temporary directory so our own git repo-ness doesn't affect it
-Before('@in-tempdir') do
-  @dirs = [Dir.mktmpdir]
+# do test in a new temp directory (outside our own git repo-ness)
+# due to https://github.com/cucumber/aruba/issues/478 aruba no longer allows
+# wandering out of `tmp/aruba` so this pop/restore is necessary
+Before('@no-repo-dir') do
+  @original_root = aruba.root_directory.pop
+  @original_dir  = aruba.current_directory.pop
+  @working_dir   = Dir.mktmpdir
+  aruba.current_directory << @working_dir
 end
 
-After('@in-tempdir') do
-  FileUtils.rm_rf(@dirs.first)
+After('@no-repo-dir') do
+  aruba.current_directory.pop
+  aruba.root_directory << @original_root
+  aruba.current_directory << @original_dir
+
+  FileUtils.rm_rf(@working_dir)
 end

--- a/features/support/path_helpers.rb
+++ b/features/support/path_helpers.rb
@@ -5,7 +5,7 @@ require 'lolcommits/platform'
 module PathHelpers
   def reject_paths_with_cmd(cmd)
     # make a new subdir that still contains cmds
-    tmpbindir = File.expand_path(File.join(@dirs, 'bin'))
+    tmpbindir = expand_path('./bin')
     FileUtils.mkdir_p tmpbindir
 
     preseve_cmds_in_path(%w(git mplayer), tmpbindir)
@@ -24,7 +24,7 @@ module PathHelpers
     newpaths << tmpbindir
 
     # use aruba/api set_environment_variable to set PATH, which will be automaticaly restored
-    set_env 'PATH', newpaths.join(File::PATH_SEPARATOR)
+    set_environment_variable 'PATH', newpaths.join(File::PATH_SEPARATOR)
   end
 
   def preseve_cmds_in_path(cmds, tmpbindir)

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -44,16 +44,13 @@ POSTINSTALL
   s.require_paths = ['lib']
 
   # non-gem dependencies
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.1'
   s.requirements << 'imagemagick'
   s.requirements << 'a webcam'
 
   # hold back upgrading (and why)
   s.add_development_dependency('aruba', '=0.6.2') # upgrading requires a lot of test code changes
-  s.add_development_dependency('rake', '=10.5.0') # ~> 11+ introduces lots of warnings from other deps
   s.add_development_dependency('cucumber', '~> 2.4.0') # > 2.4 breaks aruba, since aruba_timeout_seconds not set
-  s.add_runtime_dependency('net-http-persistent', '=2.9.4') # ~> 3+ requires Ruby 2.1
-  s.add_runtime_dependency('public_suffix', '~>2.0.0') # ~> 3+ requires Ruby 2.1
 
   # core
   s.add_runtime_dependency('methadone', '~> 1.9.5')
@@ -67,6 +64,7 @@ POSTINSTALL
   s.add_runtime_dependency('lolcommits-loltext', '~> 0.0.5')
 
   # development & test gems
+  s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')
   s.add_development_dependency('pry')
   s.add_development_dependency('rubocop')

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -49,8 +49,6 @@ POSTINSTALL
   s.requirements << 'a webcam'
 
   # hold back upgrading (and why)
-  s.add_development_dependency('aruba', '=0.6.2') # upgrading requires a lot of test code changes
-  s.add_development_dependency('cucumber', '~> 2.4.0') # > 2.4 breaks aruba, since aruba_timeout_seconds not set
 
   # core
   s.add_runtime_dependency('methadone', '~> 1.9.5')
@@ -64,6 +62,7 @@ POSTINSTALL
   s.add_runtime_dependency('lolcommits-loltext', '~> 0.0.5')
 
   # development & test gems
+  s.add_development_dependency('aruba')
   s.add_development_dependency('rake')
   s.add_development_dependency('rdoc')
   s.add_development_dependency('pry')

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -55,7 +55,7 @@ POSTINSTALL
   # core
   s.add_runtime_dependency('methadone', '~> 1.9.5')
   s.add_runtime_dependency('mercurial-ruby', '~> 0.7.12')
-  s.add_runtime_dependency('mini_magick', '~> 4.6.0')
+  s.add_runtime_dependency('mini_magick', '~> 4.8.0')
   s.add_runtime_dependency('launchy', '~> 2.4.3')
   s.add_runtime_dependency('open4', '~> 1.3.4')
   s.add_runtime_dependency('git', '~> 1.3.0')


### PR DESCRIPTION
This PR means lolcommits will now require Ruby 2.1, allowing us to (finally!!) upgrade all remaining gem dependencies (rake, Aruba, mini_magick).  Future PR's in lolcommit plugins will do the same.

Ruby 2.0 was EOL a good few years ago, and 2.1.10 is now EOL (even, 2.2.9 will be EOL soon): https://www.ruby-lang.org/en/downloads/

I've updated features so the latest Aruba and Cucumber gems can be used (and removed the @unstable tag which is no longer needed).
