### PR TITLE
Remove plugin runner order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ project adheres to [Semantic Versioning][Semver].
 
   * Your contribution here!
 
+## [0.12.0][] (15 March 2018)
+  * Use CodeClimate and simplecov for coverage reports (@matthutchinson [#367][])
+  * Remove plugin runner order (@matthutchinson [#369][])
+
 ## [0.11.0][] (4 February 2018)
   * Require at least Ruby 2.1 (@matthutchinson [#366][])
     - drop support for Ruby 2.0
@@ -316,8 +320,9 @@ project adheres to [Semantic Versioning][Semver].
   instead of compositing multiply image Caption objects (this seems to be more
   reliable to not glitch.)
 
-[Unreleased]: https://github.com/mroth/lolcommits/compare/v0.11.0...HEAD
-[0.10.0]: https://github.com/mroth/lolcommits/compare/v0.10.0...v0.11.0
+[Unreleased]: https://github.com/mroth/lolcommits/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/mroth/lolcommits/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/mroth/lolcommits/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/mroth/lolcommits/compare/v0.9.8...v0.10.0
 [0.9.8]: https://github.com/mroth/lolcommits/compare/v0.9.7...v0.9.8
 [0.9.7]: https://github.com/mroth/lolcommits/compare/v0.9.6...v0.9.7
@@ -503,3 +508,5 @@ project adheres to [Semantic Versioning][Semver].
 [#363]: https://github.com/mroth/lolcommits/pull/363
 [#365]: https://github.com/mroth/lolcommits/pull/365
 [#366]: https://github.com/mroth/lolcommits/pull/366
+[#367]: https://github.com/mroth/lolcommits/pull/367
+[#369]: https://github.com/mroth/lolcommits/pull/369

--- a/lib/lolcommits/backends/git_info.rb
+++ b/lib/lolcommits/backends/git_info.rb
@@ -80,7 +80,7 @@ module Lolcommits
     end
 
     def last_commit
-      @commit ||= repository.log.first
+      @last_commit ||= repository.log.first
     end
 
     def remote_repo?

--- a/lib/lolcommits/backends/mercurial_info.rb
+++ b/lib/lolcommits/backends/mercurial_info.rb
@@ -75,7 +75,7 @@ module Lolcommits
     end
 
     def last_commit
-      @commit ||= repository.commits.parent
+      @last_commit ||= repository.commits.parent
     end
   end
 end

--- a/lib/lolcommits/capturer/capture_windows_animated.rb
+++ b/lib/lolcommits/capturer/capture_windows_animated.rb
@@ -40,7 +40,7 @@ module Lolcommits
 
     # inspired by this code from @rdp http://tinyurl.com/y7t276bh
     def device_names
-      @_device_names ||= begin
+      @device_names ||= begin
         names      = []
         cmd_output = ''
         count      = 0

--- a/lib/lolcommits/configuration.rb
+++ b/lib/lolcommits/configuration.rb
@@ -12,7 +12,7 @@ module Lolcommits
     end
 
     def yaml
-      @_yaml ||= begin
+      @yaml ||= begin
         return Hash.new({}) unless File.exist?(configuration_file)
         # TODO: change to safe_load when Ruby 2.0.0 support drops
         # YAML.safe_load(File.open(configuration_file), [Symbol])

--- a/lib/lolcommits/gem_plugin.rb
+++ b/lib/lolcommits/gem_plugin.rb
@@ -45,7 +45,7 @@ module Lolcommits
     end
 
     def plugin_instance(runner)
-      plugin_klass.new(runner: runner, config: runner.config.yaml[name])
+      plugin_klass.new(runner: runner, config: runner.config.yaml[name], name: name)
     end
 
     def gem_name

--- a/lib/lolcommits/gem_plugin.rb
+++ b/lib/lolcommits/gem_plugin.rb
@@ -34,10 +34,6 @@ module Lolcommits
       true
     end
 
-    def name
-      gem_name.split('-', 2).last
-    end
-
     def plugin_klass
       self.class.const_get(plugin_klass_name)
     rescue StandardError => e
@@ -45,11 +41,16 @@ module Lolcommits
     end
 
     def plugin_instance(runner)
-      plugin_klass.new(runner: runner, config: runner.config.yaml[name], name: name)
+      # TODO: pass name to initializer as arg when all gems updated to accept
+      plugin_klass.new(runner: runner, config: runner.config.yaml[name])
     end
 
     def gem_name
       gem_spec.name
+    end
+
+    def name
+      gem_name.split('-', 2).last
     end
 
     private

--- a/lib/lolcommits/platform.rb
+++ b/lib/lolcommits/platform.rb
@@ -65,8 +65,8 @@ module Lolcommits
       # cli_version check will throw a MiniMagick::Error exception if IM is not
       # installed in PATH, since it attempts to parse output from `identify`
       !MiniMagick.cli_version.nil?
-    rescue StandardError
-      return false
+    rescue MiniMagick::Error
+      false
     end
 
     # Is a valid install of ffmpeg present on the system?

--- a/lib/lolcommits/plugin/base.rb
+++ b/lib/lolcommits/plugin/base.rb
@@ -9,7 +9,7 @@ module Lolcommits
 
       def initialize(runner: nil, name: nil, config: {})
         self.runner = runner
-        self.name = name
+        self.name = name || self.class.to_s
         self.configuration = config || {}
         self.options = [:enabled]
       end

--- a/lib/lolcommits/plugin/base.rb
+++ b/lib/lolcommits/plugin/base.rb
@@ -5,10 +5,11 @@ module Lolcommits
     class Base
       include Lolcommits::Plugin::ConfigurationHelper
 
-      attr_accessor :runner, :configuration, :options
+      attr_accessor :runner, :configuration, :options, :name
 
-      def initialize(runner: nil, config: {})
+      def initialize(runner: nil, name: nil, config: {})
         self.runner = runner
+        self.name = name
         self.configuration = config || {}
         self.options = [:enabled]
       end
@@ -89,29 +90,14 @@ module Lolcommits
       end
 
       # helper to log errors with a message via debug
-      def log_error(e, message)
+      def log_error(error, message)
         debug message
-        debug e.backtrace.join("\n")
+        debug error.backtrace.join("\n")
       end
 
       # uniform debug logging for plugins
       def debug(msg)
         super("#{self.class}: " + msg)
-      end
-
-      # Returns position(s) of when a plugin should run during the capture
-      # process.
-      #
-      # Defines when the plugin will execute in the capture process. This must
-      # be defined, if the method returns nil, or [] the plugin will never run.
-      # Three hook positions exist, your plugin code can execute in one or more
-      # of these.
-      #
-      # @return [Array] the position(s) (:pre_capture, :post_capture,
-      # :capture_ready)
-      #
-      def self.runner_order
-        []
       end
 
       private

--- a/lib/lolcommits/plugin_manager.rb
+++ b/lib/lolcommits/plugin_manager.rb
@@ -20,12 +20,6 @@ module Lolcommits
       @plugins.map(&:activate!)
     end
 
-    def plugins_for(position)
-      @plugins.select do |plugin|
-        Array(plugin.plugin_klass.runner_order).include?(position)
-      end
-    end
-
     # @return [Lolcommits::Plugin] finds the first plugin matching name
     def find_by_name(name)
       @plugins.find { |plugin| plugin.name =~ /^#{name}/ } unless name.empty?
@@ -33,6 +27,13 @@ module Lolcommits
 
     def plugin_names
       @plugins.map(&:name).sort
+    end
+
+    def enabled_plugins_for(runner)
+      @plugins.map do |gem_plugin|
+        plugin = gem_plugin.plugin_instance(runner)
+        plugin.enabled? ? plugin : nil
+      end.compact
     end
 
     private

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -20,21 +20,17 @@ module Lolcommits
         raise('Unknown VCS')
       end
 
-      self.sha      = vcs_info.sha if sha.nil?
-      self.message  = vcs_info.message if message.nil?
+      self.sha     = vcs_info.sha if sha.nil?
+      self.message = vcs_info.message if message.nil?
     end
 
     def execute_plugins_for(hook)
-      plugin_manager.plugins_for(hook).each do |gem_plugin|
-        plugin_name = gem_plugin.name
-        plugin      = gem_plugin.plugin_instance(self)
-        next unless plugin.enabled?
-
+      debug "#{self.class}: running enabled plugin hooks for #{hook}"
+      enabled_plugins.each do |plugin|
         if plugin.valid_configuration?
-          debug "Runner: #{plugin_name} is enabled with valid config, running #{hook}"
           plugin.send("run_#{hook}")
         else
-          puts "Warning: skipping plugin #{plugin_name} (invalid configuration, try: lolcommits --config -p #{plugin_name})"
+          puts "Warning: skipping plugin #{plugin.name} (invalid configuration, fix with: lolcommits --config -p #{plugin.name})"
         end
       end
     end
@@ -91,8 +87,8 @@ module Lolcommits
 
     private
 
-    def plugin_manager
-      @plugin_manager ||= config.plugin_manager
+    def enabled_plugins
+      @enabled_plugins ||= config.plugin_manager.enabled_plugins_for(self)
     end
 
     def image_file_type

--- a/lib/lolcommits/runner.rb
+++ b/lib/lolcommits/runner.rb
@@ -25,7 +25,7 @@ module Lolcommits
     end
 
     def execute_plugins_for(hook)
-      debug "#{self.class}: running enabled plugin hooks for #{hook}"
+      debug "#{self.class}: running all enabled plugin hooks for #{hook}"
       enabled_plugins.each do |plugin|
         if plugin.valid_configuration?
           plugin.send("run_#{hook}")

--- a/lib/lolcommits/version.rb
+++ b/lib/lolcommits/version.rb
@@ -1,4 +1,4 @@
 module Lolcommits
-  VERSION  = '0.11.0'.freeze
+  VERSION  = '0.12.0'.freeze
   GEM_NAME = 'lolcommits'.freeze
 end

--- a/lolcommits.gemspec
+++ b/lolcommits.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'lolcommits/version'
 


### PR DESCRIPTION
Instead of requiring plugins to have a runner order, always execute the hook methods for all enabled (and valid config) plugins. If the methods are not overridden then nothing will run.

This PR also passes the GemPlugin#name to the plugin initializer, so the base plugin class is aware of its gem name.